### PR TITLE
Disable `noUnusedLocals` setting in TypeScript configuration

### DIFF
--- a/src/config/tsconfig.json
+++ b/src/config/tsconfig.json
@@ -12,7 +12,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
This seems to get in the way quite often during development trial and error and kinda falls more in the domain of linting in my opinion.