### PR TITLE
Don't filter out TypeScript files from ESLint CLI args

### DIFF
--- a/src/scripts/__tests__/__snapshots__/lint.js.snap
+++ b/src/scripts/__tests__/__snapshots__/lint.js.snap
@@ -18,4 +18,4 @@ exports[`lint does not use built-in ignore with --ignore-path 1`] = `eslint --co
 
 exports[`lint does not use built-in ignore with eslintIgnore pkg prop 1`] = `eslint --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint runs on given files, but only js files 1`] = `eslint --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx ./src/index.js ./src/component.js`;
+exports[`lint runs on given files, but only js and ts files 1`] = `eslint --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx ./src/index.js ./src/index.ts ./src/component.jsx ./src/component.tsx`;

--- a/src/scripts/__tests__/lint.js
+++ b/src/scripts/__tests__/lint.js
@@ -75,12 +75,14 @@ cases(
     '--no-cache will disable caching': {
       args: ['--no-cache'],
     },
-    'runs on given files, but only js files': {
+    'runs on given files, but only js and ts files': {
       args: [
         './src/index.js',
+        './src/index.ts',
         './package.json',
         './src/index.css',
-        './src/component.js',
+        './src/component.jsx',
+        './src/component.tsx',
       ],
     },
   },

--- a/src/scripts/lint.js
+++ b/src/scripts/lint.js
@@ -46,7 +46,7 @@ if (filesGiven) {
   // we need to take all the flag-less arguments (the files that should be linted)
   // and filter out the ones that aren't js files. Otherwise json or css files
   // may be passed through
-  args = args.filter(a => !parsedArgs._.includes(a) || /\.jsx?$/.test(a))
+  args = args.filter(a => !parsedArgs._.includes(a) || /\.(j|t)sx?$/.test(a))
 }
 
 const result = spawn.sync(


### PR DESCRIPTION
The lint script was filtering file arguments passed to `eslint` to just JavaScript files causing it to miss TypeScript linting issues found on `precommit` entirely because `lint-staged` passes the staged files to `hover-scripts lint` as file arguments. This adds TypeScript files to the filter code.

Before:

```shell
hover-scripts lint file1.ts file2.tsx
```
↓
```shell
eslint
```

After:

```shell
hover-scripts lint file1.ts file2.tsx
```
↓
```shell
eslint file1.ts file2.tsx
```