### PR TITLE
Upgrade Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lodash.has": "^4.5.2",
     "lodash.omit": "^4.5.0",
     "mkdirp": "^0.5.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.5",
     "read-pkg-up": "^6.0.0",
     "resolve": "^1.14.2",
     "rimraf": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7404,10 +7404,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
Upgrade Prettier to `2.0.5`. The motivation for this, aside from generally staying up to date, came from a bug I encountered when processing MDX: https://github.com/prettier/prettier/issues/6943.