### PR TITLE
Initial support for e2e test directory

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": false,
-  "jsxBracketSameLine": false
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid"
 }

--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -31,7 +31,7 @@ const buildConfig = ({withReact = false} = {}) => {
         {
           devDependencies: rules[
             'import/no-extraneous-dependencies'
-          ][1].devDependencies.concat('jest/**'),
+          ][1].devDependencies.concat('jest/**', 'e2e/**'),
           optionalDependencies: false,
         },
       ],

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -28,6 +28,7 @@ const jestConfig = {
   testMatch: [
     `**/__tests__/**/${testMatchGlob}`,
     `test/**/${testMatchGlob}`,
+    `e2e/**/${testMatchSuffixGlob}`,
     `**/${testMatchSuffixGlob}`,
   ],
   testPathIgnorePatterns: [...ignores],


### PR DESCRIPTION
- Allow `devDependencies` in the **e2e** directory
- Include tests in the **e2e** directory (must have test extension, e.g: `*.(spec|test).ts`)