### PR TITLE
Allow `devDependencies` in Prettier configuration

### DIFF
--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -42,7 +42,11 @@ const buildConfig = ({withReact = false} = {}) => {
         {
           devDependencies: rules[
             'import/no-extraneous-dependencies'
-          ][1].devDependencies.concat('jest/**', 'e2e/**'),
+          ][1].devDependencies.concat([
+            'jest/**',
+            'e2e/**',
+            '**/prettier.config.js',
+          ]),
           optionalDependencies: false,
         },
       ],


### PR DESCRIPTION
I'm also considering just adding `**/*.config.js`...