### PR TITLE
Expose ESLint config builder + TypeScript projects option

### DIFF
--- a/src/config/eslintrc-react.js
+++ b/src/config/eslintrc-react.js
@@ -1,3 +1,10 @@
 const {buildConfig} = require('./helpers/eslint')
 
-module.exports = buildConfig({withReact: true})
+const defaultOptions = {withReact: true}
+
+const defaultExport = buildConfig(defaultOptions)
+
+defaultExport.buildConfig = options =>
+  buildConfig({...defaultOptions, ...options})
+
+module.exports = defaultExport

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -1,3 +1,7 @@
 const {buildConfig} = require('./helpers/eslint')
 
-module.exports = buildConfig()
+const defaultExport = buildConfig()
+
+defaultExport.buildConfig = buildConfig
+
+module.exports = defaultExport

--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -52,7 +52,7 @@ const buildConfig = ({withReact = false} = {}) => {
       {
         files: ['**/*.ts?(x)'],
         parserOptions: {
-          project: './tsconfig.json',
+          project: './**/*/tsconfig.json',
         },
         extends: [
           'plugin:@typescript-eslint/recommended-requiring-type-checking',

--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -22,7 +22,10 @@ const parserRules = (typescript = false) => {
   }
 }
 
-const buildConfig = ({withReact = false} = {}) => {
+const buildConfig = ({
+  withReact = false,
+  tsProjects = './**/*/tsconfig.json',
+} = {}) => {
   const ifReact = (t, f) => (withReact || hasReact ? t : f)
 
   return {
@@ -52,7 +55,7 @@ const buildConfig = ({withReact = false} = {}) => {
       {
         files: ['**/*.ts?(x)'],
         parserOptions: {
-          project: './**/*/tsconfig.json',
+          project: tsProjects,
         },
         extends: [
           'plugin:@typescript-eslint/recommended-requiring-type-checking',


### PR DESCRIPTION
- Default `parserOptions.project` **@typescript-eslint** setting with glob (`./**/*/tsconfig.json`) instead of just `./tsconfig.json` so all `tsconfig.json`'s are included by default
- Expose `buildConfig` exports from `@hover/javascript/eslint` and `@hover/javascript/eslint-react`
- Add `tsProjects` option on `buildConfig` to allow `parserOptions.project` to be set externally, e.g:

  ```js
  const { buildConfig } = require('@hover/javascript/eslint');

  module.exports = {
    extends: buildConfig({ tsProjects: ['./tsconfig.json', './packages/**/*/tsconfig.json'],
    rules: {
      // ...
    }
  }
  ```