### PR TITLE
Match tests with suffix extension in 'test/' directory

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -30,6 +30,7 @@ const jestConfig = {
   testMatch: [
     `**/__tests__/**/${testMatchGlob}`,
     `test/**/${testMatchGlob}`,
+    `test/**/${testMatchSuffixGlob}`,
     `e2e/**/${testMatchSuffixGlob}`,
     `**/${testMatchSuffixGlob}`,
   ],


### PR DESCRIPTION
Match tests with `.test.*` suffix in `test/` directory.