### PR TITLE
Fix commit script

### DIFF
--- a/src/scripts/__tests__/__snapshots__/commit.js.snap
+++ b/src/scripts/__tests__/__snapshots__/commit.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`commit bootstraps @commitlint/prompt 1`] = `
+Object {
+  cliPath: <PROJECT_ROOT>/node_modules/commitizen,
+  config: Object {
+    path: @commitlint/prompt,
+  },
+}
+`;
+
+exports[`commit bootstraps @commitlint/prompt 2`] = `node ../commit`;
+
+exports[`commit forwards arguments 1`] = `
+Object {
+  cliPath: <PROJECT_ROOT>/node_modules/commitizen,
+  config: Object {
+    path: @commitlint/prompt,
+  },
+}
+`;
+
+exports[`commit forwards arguments 2`] = `node ../commit --retry`;
+
+exports[`commit strips errant "commit" argument 1`] = `
+Object {
+  cliPath: <PROJECT_ROOT>/node_modules/commitizen,
+  config: Object {
+    path: @commitlint/prompt,
+  },
+}
+`;
+
+exports[`commit strips errant "commit" argument 2`] = `node ../commit`;
+
+exports[`commit strips errant "commit" argument and forwards arguments 1`] = `
+Object {
+  cliPath: <PROJECT_ROOT>/node_modules/commitizen,
+  config: Object {
+    path: @commitlint/prompt,
+  },
+}
+`;
+
+exports[`commit strips errant "commit" argument and forwards arguments 2`] = `node ../commit --retry`;

--- a/src/scripts/__tests__/commit.js
+++ b/src/scripts/__tests__/commit.js
@@ -1,0 +1,62 @@
+import cases from 'jest-in-case'
+import {
+  unquoteSerializer,
+  winPathSerializer,
+  relativePathSerializer,
+} from './helpers/serializers'
+
+jest.mock('commitizen/dist/cli/git-cz')
+
+expect.addSnapshotSerializer(unquoteSerializer)
+expect.addSnapshotSerializer(winPathSerializer)
+expect.addSnapshotSerializer(relativePathSerializer)
+
+cases(
+  'commit',
+  ({args = [], env = {}}) => {
+    // beforeEach
+    const {bootstrap: bootstrapMock} = require('commitizen/dist/cli/git-cz')
+
+    const originalArgv = process.argv
+    const originalExit = process.exit
+    const originalEnv = process.env
+
+    process.exit = jest.fn()
+    process.argv = ['node', '../commit', ...args]
+    process.env = env
+
+    try {
+      // tests
+      require('../commit')
+
+      expect(bootstrapMock).toHaveBeenCalledTimes(1)
+
+      const [call] = bootstrapMock.mock.calls
+      const [optionsArg, argsArg] = call
+
+      expect(optionsArg).toMatchSnapshot()
+      expect(argsArg.join(' ')).toMatchSnapshot()
+    } catch (error) {
+      throw error
+    } finally {
+      // afterEach
+      process.exit = originalExit
+      process.argv = originalArgv
+      process.env = originalEnv
+
+      jest.resetModules()
+    }
+  },
+  {
+    'bootstraps @commitlint/prompt': {},
+    'strips errant "commit" argument': {
+      args: ['commit'],
+    },
+    'forwards arguments': {
+      args: ['--retry'],
+    },
+    'strips errant "commit" argument and forwards arguments': {
+      args: ['commit', '--retry'],
+    },
+  },
+)

--- a/src/scripts/commit.js
+++ b/src/scripts/commit.js
@@ -10,9 +10,22 @@ const cliPath = [
   fromRoot('./node_modules/commitizen'),
 ].find(fs.existsSync)
 
-bootstrap({
-  cliPath,
-  config: {
-    path: '@commitlint/prompt',
+// eslint-disable-next-line no-warning-comments
+// FIXME: for some reason invoking this script with `yarn commit` now passes
+// through `'commit'` in the arguments that get parsed as "raw git arguments"
+// in the adapter which blows up said parsing behavior. I'm not sure if this
+// was related to a yarn change (`yarn [script] args` vs. `yarn [script] --
+// args`) or something else...
+//
+// Either way, this is a band-aid to filter out the rogue argument for now.
+const args = process.argv.filter(arg => arg !== 'commit')
+
+bootstrap(
+  {
+    cliPath,
+    config: {
+      path: '@commitlint/prompt',
+    },
   },
-})
+  args,
+)

--- a/src/scripts/commit.js
+++ b/src/scripts/commit.js
@@ -1,14 +1,7 @@
-const fs = require('fs')
-const path = require('path')
 const {bootstrap} = require('commitizen/dist/cli/git-cz')
-const {fromRoot} = require('../utils')
 
-const here = p => path.join(__dirname, p)
-
-const cliPath = [
-  here('../../node_modules/commitizen'),
-  fromRoot('./node_modules/commitizen'),
-].find(fs.existsSync)
+const commitizenPaths = require.resolve('commitizen/package.json').split('/')
+const cliPath = commitizenPaths.slice(0, -1).join('/')
 
 // eslint-disable-next-line no-warning-comments
 // FIXME: for some reason invoking this script with `yarn commit` now passes


### PR DESCRIPTION
#### Fix
Put band-aid in place for bug that cropped up when invoking `hover-scripts commit` from `yarn commit`

##### Additional
Also use `require.resolve` to resolve 'commitizen' path for use in `bootstrap`ing prompt adapter to make resolution more resilient and remove the dependency on `node_modules` directory.