### PR TITLE
Revert "feat: expose 'builders' and `tsProjects` option from ESLint config"

### DIFF
--- a/src/config/eslintrc-react.js
+++ b/src/config/eslintrc-react.js
@@ -1,10 +1,3 @@
 const {buildConfig} = require('./helpers/eslint')
 
-const defaultOptions = {withReact: true}
-
-const defaultExport = buildConfig(defaultOptions)
-
-defaultExport.buildConfig = options =>
-  buildConfig({...defaultOptions, ...options})
-
-module.exports = defaultExport
+module.exports = buildConfig({withReact: true})

--- a/src/config/eslintrc.js
+++ b/src/config/eslintrc.js
@@ -1,7 +1,3 @@
 const {buildConfig} = require('./helpers/eslint')
 
-const defaultExport = buildConfig()
-
-defaultExport.buildConfig = buildConfig
-
-module.exports = defaultExport
+module.exports = buildConfig()

--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -22,10 +22,7 @@ const parserRules = (typescript = false) => {
   }
 }
 
-const buildConfig = ({
-  withReact = false,
-  tsProjects = './**/*/tsconfig.json',
-} = {}) => {
+const buildConfig = ({withReact = false} = {}) => {
   const ifReact = (t, f) => (withReact || hasReact ? t : f)
 
   return {
@@ -59,7 +56,7 @@ const buildConfig = ({
       {
         files: ['**/*.ts?(x)'],
         parserOptions: {
-          project: tsProjects,
+          project: './**/*/tsconfig.json',
         },
         extends: [
           'plugin:@typescript-eslint/recommended-requiring-type-checking',


### PR DESCRIPTION
This reverts commit 77bb2d0f6ddd7e955c2d6b6d226168dd8ab762f3.