### PR TITLE
Upload coverage reports from pull requests

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -41,4 +41,4 @@ steps:
     image: ${{releaser}}
     commands:
       - yarn build
-      - node src ci-after-success
+      - yarn ci-after-success

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,7 +1,14 @@
 version: '1.0'
 
 indicators:
-  - common_release_conditions: &common_release_conditions
+  - x-common_pull_request_conditions: &common_pull_request_conditions
+      when:
+        branch:
+          ignore:
+            - master
+            - next
+
+  - x-common_release_conditions: &common_release_conditions
       when:
         branch:
           only:
@@ -29,6 +36,12 @@ steps:
     image: node:12.18.2-alpine
     commands:
       - yarn validate
+  coverage:
+    <<: *common_pull_request_conditions
+    stage: build
+    image: node:12.18.2-alpine
+    commands:
+      - yarn ci-after-success
   releaser:
     <<: *common_release_conditions
     stage: release

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,20 +1,5 @@
 version: '1.0'
 
-indicators:
-  - x-common_pull_request_conditions: &common_pull_request_conditions
-      when:
-        branch:
-          ignore:
-            - master
-            - next
-
-  - x-common_release_conditions: &common_release_conditions
-      when:
-        branch:
-          only:
-            - master
-            - next
-
 stages:
   - prepare
   - build
@@ -36,20 +21,12 @@ steps:
     image: node:12.18.2-alpine
     commands:
       - yarn validate
-  coverage:
-    <<: *common_pull_request_conditions
-    stage: build
-    image: node:12.18.2-alpine
-    commands:
-      - yarn ci-after-success
   releaser:
-    <<: *common_release_conditions
     stage: release
     type: build
     image_name: '${{CF_REPO_NAME}}-releaser'
     dockerfile: Dockerfile
   release:
-    <<: *common_release_conditions
     stage: release
     image: ${{releaser}}
     commands:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "node src lint",
     "format": "node src format",
     "validate": "node src validate",
-    "commit": "node src commit"
+    "commit": "node src commit",
+    "ci-after-success": "node src ci-after-success"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
The `ci-after-success` script handles both Codecov reporting and releases, but it was only running on `master` and `next` and therefore was not publishing coverage reports from PRs.