### PR TITLE
⚙ Shorten Dependabot development dependencies prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  pull-request-branch-name:
-    separator: "-"
-  commit-message:
-    prefix: "feat(deps):"
-    prefix-development: "build(deps-dev):"
-    include: "scope"
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    pull-request-branch-name:
+      separator: '-'
+    commit-message:
+      prefix: 'feat(deps):'
+      prefix-development: 'build(deps):'
+      include: 'scope'


### PR DESCRIPTION
Apparently it has a 15 character max...