### PR TITLE
Enable React Hooks recommended rules

### DIFF
--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -33,6 +33,7 @@ const buildConfig = ({withReact = false} = {}) => {
       prettier(),
       prettier('@typescript-eslint'),
       ifReact(prettier('react')),
+      ifReact('plugin:react-hooks/recommended'),
     ].filter(Boolean),
     rules: {
       'prettier/prettier': 'error',


### PR DESCRIPTION
All this time we've been loading the plugin without enabling any of the rules...