### PR TITLE
Expose Prettier `format` API

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/api'

--- a/api.js
+++ b/api.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/api')

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,7 +18,13 @@ module.exports = {
     'scope-enum': [
       1,
       'always',
-      [...ls('./src/config'), ...ls('./src/scripts'), 'deps', 'build'],
+      [
+        ...ls('./src/config'),
+        ...ls('./src/scripts'),
+        ...ls('./src/api'),
+        'deps',
+        'build',
+      ],
     ],
   },
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "scripts": {
     "test": "node src test",
     "test:update": "node src test --updateSnapshot",
-    "build": "node src build",
+    "build": "run-p build:*",
+    "build:source": "node src build",
+    "build:types": "tsc -p src/",
     "lint": "node src lint",
     "format": "node src format",
     "validate": "node src validate",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     }
   },
   "files": [
+    "api",
+    "api.js",
+    "api.d.ts",
     "dist",
     "babel.js",
     "commitlint.js",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "rollup-plugin-size-snapshot": "^0.12.0",
     "rollup-plugin-terser": "^6.1.0",
     "semver": "^7.1.3",
-    "typescript": "^3.7.5",
+    "typescript": "^3.9.7",
     "which": "^2.0.2",
     "yargs-parser": "^18.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
   "homepage": "https://github.com/hoverinc/hover-javascript#readme",
   "devDependencies": {
     "jest-in-case": "^1.0.2",
+    "npm-run-all": "^4.1.5",
     "slash": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "format": "node src format",
     "validate": "node src validate",
     "commit": "node src commit",
-    "ci-after-success": "node src ci-after-success"
+    "ci-after-success": "node src ci-after-success",
+    "start": "run-p start:*",
+    "start:source": "yarn build:source --watch",
+    "start:types": "tsc -b -w --preserveWatchOutput src/"
   },
   "husky": {
     "hooks": {

--- a/src/api/__mocks__/prettier.js
+++ b/src/api/__mocks__/prettier.js
@@ -1,0 +1,3 @@
+module.exports = {
+  format: jest.fn(() => '[formatted-code]'),
+}

--- a/src/api/__tests__/__snapshots__/api.js.snap
+++ b/src/api/__tests__/__snapshots__/api.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`format calls \`prettier.format\` with internal Prettier configuration 1`] = `
+Object {
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "always",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+}
+`;
+
+exports[`format merges provided \`options\` with internal Prettier configuration 1`] = `
+Object {
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "parser": "css",
+  "printWidth": 100,
+  "proseWrap": "always",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "useTabs": false,
+}
+`;

--- a/src/api/__tests__/api.js
+++ b/src/api/__tests__/api.js
@@ -1,0 +1,34 @@
+import cases from 'jest-in-case'
+import prettier from 'prettier'
+import {format} from '../'
+
+cases(
+  'format',
+  ({source = 'const id = x => x', options = {}}) => {
+    // beforeEach
+    format(source, options)
+
+    try {
+      expect(prettier.format).toHaveBeenCalledTimes(1)
+      expect(prettier.format).toHaveBeenCalledWith(source, expect.any(Object))
+
+      const [call] = prettier.format.mock.calls
+
+      expect(call[1]).toMatchSnapshot()
+    } catch (error) {
+      throw error
+    } finally {
+      // afterEach
+
+      prettier.format.mockReset()
+      jest.resetModules()
+    }
+  },
+  {
+    'calls `prettier.format` with internal Prettier configuration': {},
+    'merges provided `options` with internal Prettier configuration': {
+      /** @type {import('prettier').Options} */
+      options: {printWidth: 100, arrowParens: 'always', parser: 'css'},
+    },
+  },
+)

--- a/src/api/format.js
+++ b/src/api/format.js
@@ -1,0 +1,16 @@
+/** @typedef {import('prettier').Options} Options */
+
+const prettier = require('prettier')
+const config = require('../config/prettierrc')
+
+/**
+ *
+ * @param {string} source
+ * @param {Options} options
+ *
+ * @returns {string} Formatted source
+ */
+const format = (source, options) =>
+  prettier.format(source, {...config, ...options})
+
+module.exports = format

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  format: require('./format'),
+}

--- a/src/config/prettierrc.js
+++ b/src/config/prettierrc.js
@@ -1,3 +1,4 @@
+/** @type {import('prettier').Options} */
 module.exports = {
   arrowParens: 'avoid',
   endOfLine: 'lf',

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./config/tsconfig.json",
   "include": ["./api"],
+  "exclude": ["./**/__tests__/*"],
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./config/tsconfig.json",
+  "include": ["./api"],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "../dist",
+    "rootDir": "."
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6230,6 +6230,11 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@5.0.0, meow@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
@@ -6539,6 +6544,21 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-run-all@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -6944,6 +6964,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -7898,6 +7923,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-quote@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -8238,6 +8268,14 @@ string.prototype.matchall@^4.0.2:
     internal-slot "^1.0.2"
     regexp.prototype.flags "^1.3.0"
     side-channel "^1.0.2"
+
+string.prototype.padend@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz#dc08f57a8010dc5c153550318f67e13adbb72ac3"
+  integrity sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8724,10 +8724,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.5:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 underscore@~1.8.3:
   version "1.8.3"


### PR DESCRIPTION
- Add `api` package entry point
- Expose a pre-configured version of Prettier's `format` API

##### Additional
- Add `tsc` to build process to start outputting selective definitions via JSON type annotations