### PR TITLE
💚 Ignore *.d.ts files at the project root

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+coverage/
+dist/
+/*.d.ts


### PR DESCRIPTION
These will always be package entries which shouldn't need linting and furthermore break the build sometimes on the `import/no-unresolved` rule when linting happens before a build is complete as they forward exports from modules in the `dist` directory which is created during the build.