### PR TITLE
feat(scripts/lint): allow glob arguments to linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .opt-out
 .DS_Store
 .eslintcache
+.idea

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -5,12 +5,10 @@ const doctoc = resolveBin('doctoc')
 
 module.exports = {
   'README.md': [`${doctoc} --maxlevel 3 --notitle`],
-  '*.+(json|yml|yaml|css|less|scss|md|graphql|mdx|vue)': [
+  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)': [
     `${hoverScripts} format`,
-    `${hoverScripts} test --findRelatedTests`,
   ],
   '*.+(js|jsx|ts|tsx)': [
-    `${hoverScripts} format`,
     `${hoverScripts} lint`,
     `${hoverScripts} test --findRelatedTests`,
   ],

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,13 +1,17 @@
 const {resolveHoverScripts, resolveBin} = require('../utils')
 
-const kcdScripts = resolveHoverScripts()
+const hoverScripts = resolveHoverScripts()
 const doctoc = resolveBin('doctoc')
 
 module.exports = {
   'README.md': [`${doctoc} --maxlevel 3 --notitle`],
-  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)': [
-    `${kcdScripts} format`,
-    `${kcdScripts} lint`,
-    `${kcdScripts} test --findRelatedTests`,
+  '*.+(json|yml|yaml|css|less|scss|md|graphql|mdx|vue)': [
+    `${hoverScripts} format`,
+    `${hoverScripts} test --findRelatedTests`,
+  ],
+  '*.+(js|jsx|ts|tsx)': [
+    `${hoverScripts} format`,
+    `${hoverScripts} lint`,
+    `${hoverScripts} test --findRelatedTests`,
   ],
 }

--- a/src/scripts/__tests__/__snapshots__/lint.js.snap
+++ b/src/scripts/__tests__/__snapshots__/lint.js.snap
@@ -17,5 +17,3 @@ exports[`lint does not use built-in ignore with .eslintignore file 1`] = `eslint
 exports[`lint does not use built-in ignore with --ignore-path 1`] = `eslint --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx --ignore-path ./my-ignore .`;
 
 exports[`lint does not use built-in ignore with eslintIgnore pkg prop 1`] = `eslint --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
-
-exports[`lint runs on given files, but only js and ts files 1`] = `eslint --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx ./src/index.js ./src/index.ts ./src/component.jsx ./src/component.tsx`;

--- a/src/scripts/__tests__/lint.js
+++ b/src/scripts/__tests__/lint.js
@@ -75,15 +75,5 @@ cases(
     '--no-cache will disable caching': {
       args: ['--no-cache'],
     },
-    'runs on given files, but only js and ts files': {
-      args: [
-        './src/index.js',
-        './src/index.ts',
-        './package.json',
-        './src/index.css',
-        './src/component.jsx',
-        './src/component.tsx',
-      ],
-    },
   },
 )

--- a/src/scripts/lint.js
+++ b/src/scripts/lint.js
@@ -3,7 +3,7 @@ const spawn = require('cross-spawn')
 const yargsParser = require('yargs-parser')
 const {hasPkgProp, resolveBin, hasFile, fromRoot} = require('../utils')
 
-let args = process.argv.slice(2)
+const args = process.argv.slice(2)
 const here = p => path.join(__dirname, p)
 const hereRelative = p => here(p).replace(process.cwd(), '.')
 const parsedArgs = yargsParser(args)
@@ -41,13 +41,6 @@ const extensions = args.includes('--ext') ? [] : ['--ext', '.js,.jsx,.ts,.tsx']
 const filesGiven = parsedArgs._.length > 0
 
 const filesToApply = filesGiven ? [] : ['.']
-
-if (filesGiven) {
-  // we need to take all the flag-less arguments (the files that should be linted)
-  // and filter out the ones that aren't js files. Otherwise json or css files
-  // may be passed through
-  args = args.filter(a => !parsedArgs._.includes(a) || /\.(j|t)sx?$/.test(a))
-}
 
 const result = spawn.sync(
   resolveBin('eslint'),


### PR DESCRIPTION
Remove file filtering behavior from lint command so it can be used like eslint with glob patterns

Updated tests.  

Updated lintstagedrc.js to only run lint on .js(x), .ts(x) files to simulate same behavior