### PR TITLE
feat(config/eslintrc): turn off prop types validation for typescript

### DIFF
--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -19,6 +19,7 @@ const parserRules = (typescript = false) => {
     'no-throw-literal': isOff(typescript),
     '@typescript-eslint/no-implied-eval': isOff(!typescript),
     '@typescript-eslint/no-throw-literal': isOff(!typescript),
+    'react/prop-types': isOff(typescript),
   }
 }
 


### PR DESCRIPTION
Typescript has its own mechanism for validating prop types and the react proptypes are redundant