### PR TITLE
Allow void statements

### DIFF
--- a/src/config/helpers/eslint.js
+++ b/src/config/helpers/eslint.js
@@ -55,6 +55,7 @@ const buildConfig = ({withReact = false} = {}) => {
           optionalDependencies: false,
         },
       ],
+      'no-void': ['error', {allowAsStatement: true}],
       ...parserRules(false, isReact),
     },
     overrides: [


### PR DESCRIPTION
This is necessary to mark 'dangling promises' as intentionally dangling, see: https://github.com/typescript-eslint/typescript-eslint/blob/v4.3.0/packages/eslint-plugin/docs/rules/no-floating-promises.md#ignorevoid.