### PR TITLE
Exclude mocks from TypeScript build

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./config/tsconfig.json",
   "include": ["./api"],
-  "exclude": ["./**/__tests__/*"],
+  "exclude": ["./**/__tests__/*", "./**/__mocks__/*"],
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Oops, we were compiling `__mocks__` directories.