### PR TITLE
Fix missing TypeScript configuration and Jest transform for JavaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "node src test",
     "test:update": "node src test --updateSnapshot",
     "build": "run-p build:*",
-    "build:source": "babel --source-maps --out-dir dist --ignore '**/__tests__/**','**/__mocks__/**' src",
+    "build:source": "babel --source-maps --out-dir dist --ignore '**/__tests__/**','**/__mocks__/**' --copy-files --no-copy-ignored src",
     "build:types": "tsc -p src/",
     "lint": "node src lint",
     "format": "node src format",

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -48,7 +48,7 @@ const jestConfig = {
 }
 
 if (hasAnyDep('ts-jest')) {
-  jestConfig.preset = 'ts-jest'
+  jestConfig.preset = 'ts-jest/presets/js-with-ts'
   jestConfig.globals['ts-jest'] = {
     diagnostics: {
       warnOnly: true,


### PR DESCRIPTION
- Switch from `ts-jest` preset to `ts-jest/presets/js-with-ts` in order to support JS files when using `ts-jest`
- Add `--copy-files` to build script to fix missing `tsconfig.json` in release