### PR TITLE
Update `api` entry points to expose `commit` module

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -1,1 +1,0 @@
-export * from './dist/api'

--- a/api.js
+++ b/api.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/api')

--- a/api/commit.d.ts
+++ b/api/commit.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/api/commit'

--- a/api/commit.js
+++ b/api/commit.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/api/commit')

--- a/api/index.d.ts
+++ b/api/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/api'

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/api')


### PR DESCRIPTION
We were only exposing the index of `api`. We need to expose `api/commit` as an entry point as well to get at the named exports.