### PR TITLE
🐛 Fix quoting in release command

### DIFF
--- a/src/scripts/__tests__/__snapshots__/ci-after-success.js.snap
+++ b/src/scripts/__tests__/__snapshots__/ci-after-success.js.snap
@@ -20,7 +20,7 @@ exports[`ci-after-success configures semantic release with internal configuratio
 
 exports[`ci-after-success configures semantic release with internal configuration when no local configuration exists 2`] = `
 Array [
-  concurrently --prefix [{name}] --names release --prefix-colors bgBlue.bold.reset "echo installing semantic-release && npx -p semantic-release@17 -c 'echo running semantic-release && semantic-release' --extends ./src/config/release.config.js",
+  concurrently --prefix [{name}] --names release --prefix-colors bgBlue.bold.reset "echo installing semantic-release && npx -p semantic-release@17 -c 'echo running semantic-release && semantic-release --extends ./src/config/release.config.js'",
 ]
 `;
 

--- a/src/scripts/ci-after-success.js
+++ b/src/scripts/ci-after-success.js
@@ -27,11 +27,11 @@ const branch = CF_BRANCH || TRAVIS_BRANCH
 const isCI = parseEnv('TRAVIS', false) || parseEnv('CI', false)
 
 const codecovCommand = `echo installing codecov && npx -p codecov@3 -c 'echo running codecov && codecov'`
-const releaseCommand = `echo installing semantic-release && npx -p semantic-release@17 -c 'echo running semantic-release && semantic-release'${
+const releaseCommand = `echo installing semantic-release && npx -p semantic-release@17 -c 'echo running semantic-release && semantic-release${
   hasLocalConfig('release')
     ? ''
     : ` --extends ${hereRelative('../config/release.config.js')}`
-}`
+}'`
 
 const autorelease =
   pkg.version === '0.0.0-semantically-released' &&


### PR DESCRIPTION
The `--extends` CLI flag for the `semantic-release` flag was outside of quotes
and therefore was doing nothing.