### PR TITLE
➡️ Make KCD ESLint configuration a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "doctoc": "^2.0.0",
     "eslint": "^7.19.0",
     "eslint-config-airbnb-typescript": "^11.0.0",
-    "eslint-config-kentcdodds": "^15.0.0",
     "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^24.0.1",
@@ -122,6 +121,7 @@
     "@babel/core": "^7.12.13",
     "@babel/preset-env": "^7.11.5",
     "babel-jest": "^26.5.2",
+    "eslint-config-kentcdodds": "^15.0.0",
     "jest-in-case": "^1.0.2",
     "npm-run-all": "^4.1.5",
     "slash": "^3.0.0"


### PR DESCRIPTION
Kent's ESLint configuration (`eslint-config-kentcdodds`) should be a `devDependency` as we only use it to format this codebase in order to preserve compatibility with the upstream repo. The configuration we provide externally is not based on this configuration.
