### PR TITLE
🔪 Remove unnused resolve dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "mkdirp": "^1.0.3",
     "prettier": "^2.2.1",
     "read-pkg-up": "^7.0.1",
-    "resolve": "^1.15.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.0.3",
     "which": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7571,7 +7571,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.18.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==


### PR DESCRIPTION
🔪 Remove **resolve**, it must have been around for the build scripts I removed in 5.0.
