### PR TITLE
🐛 Fix JavaScript linting compatibility issue

### DIFF
--- a/src/config/helpers/build-eslint.js
+++ b/src/config/helpers/build-eslint.js
@@ -30,6 +30,8 @@ const parserRules = (typescript = false, react = false) => {
     'no-throw-literal': isOff(typescript),
     '@typescript-eslint/no-implied-eval': isOff(!typescript),
     '@typescript-eslint/no-throw-literal': isOff(!typescript),
+    '@typescript-eslint/dot-notation': isOff(!typescript),
+    '@typescript-eslint/return-await': isOff(!typescript),
     ...propTypes,
   }
 }


### PR DESCRIPTION
To ensure compatibility with JavaScript without the need for `parserOptions`
and a `tsconfig.json` we need to make sure any type-aware rules are disabled for JavaScript files. Some new type-aware rules were added in a recent update of **@typescript-eslint/eslint-plugin** so we need to disable them.
