### PR TITLE
🤷🏻 Allow unsafe (any) assignment + returns in tests

### DIFF
--- a/src/config/helpers/build-eslint.js
+++ b/src/config/helpers/build-eslint.js
@@ -80,6 +80,8 @@ const buildConfig = ({withReact = false} = {}) => {
       {
         files: testMatch,
         rules: {
+          '@typescript-eslint/no-unsafe-assignment': 'off',
+          '@typescript-eslint/no-unsafe-return': 'off',
           'no-empty': ['error', {allowEmptyCatch: true}],
         },
       },


### PR DESCRIPTION
Allow some `any` here and there in tests (disable `@typescript-eslint/unsafe-returns` and `@typescript-eslint/unsafe-assignment` in test files). 
