### PR TITLE
Add consistent entrypoint for React ESLint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ module.exports = {
 }
 ```
 
+##### React Preset
+
+> ℹ️ The standard preset attempts to detect a React dependency and enable this
+> preset automatically so this is usually only necessary in edge cases where
+> React is not detected (such as a monorepo)
+
+A React preset is available that includes additional React-specific rules as
+well as the **eslint-plugin-react-hooks** plugin.
+
+```js
+module.exports = {
+  extends: require.resolve('@hover/javascript/eslint/react'),
+}
+```
+
 #### Prettier
 
 Or, for Prettier, a `.prettierrc.js` with:

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/config/eslintrc-react')


### PR DESCRIPTION
Expose the React-specific ESLint preset at `@hover/javascript/eslint/react` (we'll deprecate `@hover/javascript/eslint-react` soon). Also add documentation for the React preset.
