### PR TITLE
✨ Parallelize lint + test tasks in lint-staged configuration

### DIFF
--- a/src/config/helpers/build-lint-staged.js
+++ b/src/config/helpers/build-lint-staged.js
@@ -2,14 +2,27 @@ const {resolveHoverScripts, resolveBin} = require('../../utils')
 
 const hoverScripts = resolveHoverScripts()
 const doctoc = resolveBin('doctoc')
+
 const defaultTestCommand = `${hoverScripts} test --findRelatedTests`
 
+const sourceExtensions = ['js', 'jsx', 'ts', 'tsx']
+
+const readmeGlob = 'README.md'
+const formatGlob =
+  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)'
+
+// This works around the limitation imposed by using globs as keys in the
+// configuration. We want to run the lint and test commands on the same glob,
+// but we want to do so in parallel. If we specify the commands in an array
+// under the same glob key, they always run in sequence.
+const lintGlob = `*.+(${sourceExtensions.join('|')})`
+const testGlob = `*.+(${sourceExtensions.reverse().join('|')})`
+
 const buildConfig = (testCommand = defaultTestCommand) => ({
-  'README.md': [`${doctoc} --maxlevel 4 --notitle`],
-  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)': [
-    `${hoverScripts} format`,
-  ],
-  '*.+(js|jsx|ts|tsx)': [`${hoverScripts} lint`, testCommand],
+  [readmeGlob]: [`${doctoc} --maxlevel 4 --notitle`],
+  [formatGlob]: [`${hoverScripts} format`],
+  [lintGlob]: [`${hoverScripts} lint`],
+  [testGlob]: [testCommand],
 })
 
 module.exports = {buildConfig}

--- a/src/scripts/__tests__/__snapshots__/pre-commit.js.snap
+++ b/src/scripts/__tests__/__snapshots__/pre-commit.js.snap
@@ -58,7 +58,7 @@ Array [
 exports[`pre-commit overrides built-in test command with --test-command 2`] = `
 Array [
   .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint","yarn test:custom --findRelatedTests foo.js"]},
+  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
 ]
 `;
 
@@ -72,7 +72,7 @@ Array [
 exports[`pre-commit overrides built-in test command with --test-command and forwards args 2`] = `
 Array [
   .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint","yarn test:custom --findRelatedTests foo.js"]},
+  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
 ]
 `;
 
@@ -86,7 +86,7 @@ Array [
 exports[`pre-commit overrides built-in test command with --testCommand 2`] = `
 Array [
   .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint","yarn test:custom --findRelatedTests foo.js"]},
+  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
 ]
 `;
 
@@ -100,7 +100,7 @@ Array [
 exports[`pre-commit overrides built-in test command with --testCommand and forwards args 2`] = `
 Array [
   .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint","yarn test:custom --findRelatedTests foo.js"]},
+  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
 ]
 `;
 


### PR DESCRIPTION
Split up lint and test tasks in the built-in **lint-staged** configuration so that they will run in parallel.
