### PR TITLE
✨ Allow development dependencies in test directory

### DIFF
--- a/src/config/helpers/build-eslint.js
+++ b/src/config/helpers/build-eslint.js
@@ -57,6 +57,7 @@ const buildConfig = ({withReact = false} = {}) => {
             'import/no-extraneous-dependencies'
           ][1].devDependencies.concat([
             'jest/**',
+            'test/**',
             'e2e/**',
             '**/*.config.{js,ts}',
           ]),


### PR DESCRIPTION
Allow `devDependencies` to be imported in the `test/` directory.
