### PR TITLE
🐛 Fix argument forwarding for commit-msg script

### DIFF
--- a/src/scripts/__tests__/__snapshots__/commit-msg.js.snap
+++ b/src/scripts/__tests__/__snapshots__/commit-msg.js.snap
@@ -4,8 +4,8 @@ exports[`commit-msg adds env flag with HUSKY_GIT_PARAMS when available 1`] = `co
 
 exports[`commit-msg calls @commitlint/cli with default args 1`] = `commitlint --config ./src/config/commitlint.config.js`;
 
-exports[`commit-msg does not use built-in config with --config 1`] = `commitlint`;
+exports[`commit-msg does not use built-in config with --config 1`] = `commitlint --config ./custom-config.js`;
 
 exports[`commit-msg does not use built-in config with commitlint.config.js file 1`] = `commitlint`;
 
-exports[`commit-msg forwards args 1`] = `commitlint --config ./src/config/commitlint.config.js`;
+exports[`commit-msg forwards args 1`] = `commitlint --config ./src/config/commitlint.config.js --edit .git/COMMIT_EDITMSG`;

--- a/src/scripts/__tests__/__snapshots__/commit-msg.js.snap
+++ b/src/scripts/__tests__/__snapshots__/commit-msg.js.snap
@@ -2,10 +2,12 @@
 
 exports[`commit-msg adds env flag with HUSKY_GIT_PARAMS when available 1`] = `commitlint --env HUSKY_GIT_PARAMS --config ./src/config/commitlint.config.js`;
 
-exports[`commit-msg calls @commitlint/cli with default args 1`] = `commitlint --config ./src/config/commitlint.config.js`;
+exports[`commit-msg calls @commitlint/cli with default args 1`] = `commitlint --config ./src/config/commitlint.config.js --edit`;
+
+exports[`commit-msg defaults to \`--edit\` when no args are passed and HUSKY_GIT_PARAMS is not available 1`] = `commitlint --config ./src/config/commitlint.config.js --edit`;
 
 exports[`commit-msg does not use built-in config with --config 1`] = `commitlint --config ./custom-config.js`;
 
-exports[`commit-msg does not use built-in config with commitlint.config.js file 1`] = `commitlint`;
+exports[`commit-msg does not use built-in config with commitlint.config.js file 1`] = `commitlint --edit`;
 
 exports[`commit-msg forwards args 1`] = `commitlint --config ./src/config/commitlint.config.js --edit .git/COMMIT_EDITMSG`;

--- a/src/scripts/__tests__/commit-msg.js
+++ b/src/scripts/__tests__/commit-msg.js
@@ -62,5 +62,8 @@ cases(
     'adds env flag with HUSKY_GIT_PARAMS when available': {
       env: {HUSKY_GIT_PARAMS: 'husky-git-params'},
     },
+    'defaults to `--edit` when no args are passed and HUSKY_GIT_PARAMS is not available': {
+      env: {HUSKY_GIT_PARAMS: undefined, args: []},
+    },
   },
 )

--- a/src/scripts/__tests__/commit-msg.js
+++ b/src/scripts/__tests__/commit-msg.js
@@ -57,7 +57,7 @@ cases(
       hasFile: filename => filename === 'commitlint.config.js',
     },
     'forwards args': {
-      args: ['--verbose'],
+      args: ['--edit', '.git/COMMIT_EDITMSG'],
     },
     'adds env flag with HUSKY_GIT_PARAMS when available': {
       env: {HUSKY_GIT_PARAMS: 'husky-git-params'},

--- a/src/scripts/commit-msg.js
+++ b/src/scripts/commit-msg.js
@@ -14,6 +14,7 @@ const useBuiltinConfig =
   !hasFile('commitlint.config.js')
 
 const env = huskyGitParams ? ['--env', 'HUSKY_GIT_PARAMS'] : []
+const defaultEdit = !huskyGitParams && args.length === 0 ? ['--edit'] : []
 
 const config = useBuiltinConfig
   ? ['--config', hereRelative('../config/commitlint.config.js')]
@@ -21,7 +22,7 @@ const config = useBuiltinConfig
 
 const result = spawn.sync(
   resolveBin('@commitlint/cli', {executable: 'commitlint'}),
-  [...env, ...config, ...args],
+  [...env, ...config, ...args, ...defaultEdit],
   {
     stdio: 'inherit',
   },

--- a/src/scripts/commit-msg.js
+++ b/src/scripts/commit-msg.js
@@ -21,7 +21,7 @@ const config = useBuiltinConfig
 
 const result = spawn.sync(
   resolveBin('@commitlint/cli', {executable: 'commitlint'}),
-  [...env, ...config],
+  [...env, ...config, ...args],
   {
     stdio: 'inherit',
   },


### PR DESCRIPTION
Arguments weren't actually being forwarded to **@commitlint/cli**... missed this due to snapshot based tests ☹.

- Fixes use case of actually passing `--edit $1` for example
- Also fixes passing a custom config via `--config`

✨ Also support Husky 6 by defaulting to `--edit` when no arguments are passed.
