### PR TITLE
🐛 Include TypeScript as a dependency (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.5",
     "tslib": "^2.2.0",
+    "typescript": "^4",
     "which": "^2.0.2",
     "yargs-parser": "^20.2.7"
   },
@@ -123,7 +124,6 @@
     "husky": "^4.3.8",
     "jest-in-case": "^1.0.2",
     "npm-run-all": "^4.1.5",
-    "slash": "^3.0.0",
-    "typescript": "^4.2.3"
+    "slash": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8411,10 +8411,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
-  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
+typescript@^4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 unbox-primitive@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Include TypeScript as a `dependency` as opposed to a `devDependency` now that we're bundling **ts-jest**.
