### PR TITLE
🐛 Fix branch parsing for GitHub actions

### DIFF
--- a/src/scripts/__tests__/ci-after-success.js
+++ b/src/scripts/__tests__/ci-after-success.js
@@ -21,10 +21,10 @@ cases(
     },
   }) => {
     // beforeEach
-
     const {sync: crossSpawnSyncMock} = require('cross-spawn')
     const utils = require('../../utils')
     utils.resolveBin = (modName, {executable = modName} = {}) => executable
+
     const originalEnvs = Object.keys(env).map(envKey => {
       const orig = process.env[envKey]
       process.env[envKey] = env[envKey]
@@ -82,7 +82,8 @@ cases(
     },
     'calls concurrently with both scripts when on github actions': {
       env: {
-        GITHUB_REF: '/refs/heads/main',
+        CF_BRANCH: '',
+        GITHUB_REF: 'refs/heads/main',
         TRAVIS_PULL_REQUEST: 'false',
       },
     },

--- a/src/scripts/ci-after-success.js
+++ b/src/scripts/ci-after-success.js
@@ -23,7 +23,8 @@ const releaseBranches = [
   'beta',
   'alpha',
 ]
-const branch = CF_BRANCH || TRAVIS_BRANCH || GITHUB_REF.replace(/\/refs\/.*\//)
+const branch =
+  CF_BRANCH || TRAVIS_BRANCH || GITHUB_REF.replace(/refs\/.*\//, '')
 const isCI = parseEnv('TRAVIS', false) || parseEnv('CI', false)
 
 const codecovCommand = `echo installing codecov && npx -p codecov@3 -c 'echo running codecov && codecov'`


### PR DESCRIPTION
`GITHUB_REF` doesn't have a leading slash.
