### PR TITLE
✨ Expose ts-jest utils API

### DIFF
--- a/api/test.d.ts
+++ b/api/test.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/api/test' // eslint-disable-line import/export

--- a/api/test.js
+++ b/api/test.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/api/test')

--- a/src/api/__tests__/test.js
+++ b/src/api/__tests__/test.js
@@ -1,0 +1,11 @@
+import * as utilsExports from 'ts-jest/utils'
+import * as testExports from '../test' // eslint-disable-line import/namespace
+
+describe('re-exporting ts-jest utils', () => {
+  test.each(Object.entries(utilsExports).filter(([key]) => key !== 'default'))(
+    'forwards `%s` export',
+    (exportName, exportValue) => {
+      expect(testExports).toHaveProperty(exportName, exportValue)
+    },
+  )
+})

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,0 +1,1 @@
+export * from 'ts-jest/utils'

--- a/src/config/commitlint.config.js
+++ b/src/config/commitlint.config.js
@@ -20,7 +20,7 @@ module.exports = {
         'test',
       ],
     ],
-    'scope-case': [1, 'always', 'kebab-case'],
+    'scope-case': [1, 'always', 'lowercase'],
     'scope-enum': [0, 'always', scopes.build()],
   },
 }


### PR DESCRIPTION
- Use `lowercase` instead of `kebab-case` for **scope-case**
- Expose **ts-jest** `utils` at `@hover/javascript/api/test`
