### PR TITLE
🐛 Fix argument parsing

### DIFF
--- a/src/scripts/__tests__/__snapshots__/commit.js.snap
+++ b/src/scripts/__tests__/__snapshots__/commit.js.snap
@@ -21,25 +21,3 @@ Object {
 `;
 
 exports[`commit forwards arguments 2`] = `node ../commit --retry`;
-
-exports[`commit strips errant "commit" argument 1`] = `
-Object {
-  cliPath: <PROJECT_ROOT>/node_modules/commitizen,
-  config: Object {
-    path: @commitlint/prompt,
-  },
-}
-`;
-
-exports[`commit strips errant "commit" argument 2`] = `node ../commit`;
-
-exports[`commit strips errant "commit" argument and forwards arguments 1`] = `
-Object {
-  cliPath: <PROJECT_ROOT>/node_modules/commitizen,
-  config: Object {
-    path: @commitlint/prompt,
-  },
-}
-`;
-
-exports[`commit strips errant "commit" argument and forwards arguments 2`] = `node ../commit --retry`;

--- a/src/scripts/__tests__/commit.js
+++ b/src/scripts/__tests__/commit.js
@@ -49,14 +49,8 @@ cases(
   },
   {
     'bootstraps @commitlint/prompt': {},
-    'strips errant "commit" argument': {
-      args: ['commit'],
-    },
     'forwards arguments': {
       args: ['--retry'],
-    },
-    'strips errant "commit" argument and forwards arguments': {
-      args: ['commit', '--retry'],
     },
   },
 )

--- a/src/scripts/commit.js
+++ b/src/scripts/commit.js
@@ -3,16 +3,6 @@ const {bootstrap} = require('commitizen/dist/cli/git-cz')
 const commitizenPaths = require.resolve('commitizen/package.json').split('/')
 const cliPath = commitizenPaths.slice(0, -1).join('/')
 
-// eslint-disable-next-line no-warning-comments
-// FIXME: for some reason invoking this script with `yarn commit` now passes
-// through `'commit'` in the arguments that get parsed as "raw git arguments"
-// in the adapter which blows up said parsing behavior. I'm not sure if this
-// was related to a yarn change (`yarn [script] args` vs. `yarn [script] --
-// args`) or something else...
-//
-// Either way, this is a band-aid to filter out the rogue argument for now.
-const args = process.argv.filter(arg => arg !== 'commit')
-
 bootstrap(
   {
     cliPath,
@@ -20,5 +10,5 @@ bootstrap(
       path: '@commitlint/prompt',
     },
   },
-  args,
+  process.argv,
 )


### PR DESCRIPTION
Update argument forwarding logic in `run-script` wrapper to dynamically find sub-script command and therefore pass the correct arguments to the script without hard-coding the script names. I was not aware of this hard-coded bit and therefore some scripts were receiving the sub-script command in their `process.argv` erroneously.

This removes the need for a workaround I had added while unaware of this issue and fixes the Husky 6 support in `commit-msg`.