### PR TITLE
✨ Resolve JSON modules by default in TypeScript configuration

### DIFF
--- a/src/config/tsconfig.json
+++ b/src/config/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitThis": true,
     "noUnusedLocals": false,
     "noUnusedParameters": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Set `resolveJsonModule` to `true` by default in the exposed `tsconfig.json`.
