### PR TITLE
🐛 Fix test API entrypoint

### DIFF
--- a/api/test.js
+++ b/api/test.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/api/test')
+module.exports = require('../dist/api/test')


### PR DESCRIPTION
Type definitions were pointing to the correct place, but `api/test` was not pointing to `/dist` correctly.
