### PR TITLE
🐛 Fix api/test again

### DIFF
--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,1 +1,1 @@
-export * from 'ts-jest/utils'
+module.exports = require('ts-jest/utils')


### PR DESCRIPTION
Derp, was forwarding *ts-jest* exports with ESM instead of CommonJS.
