### PR TITLE
💚 Update auto-merge configuration

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -24,7 +24,7 @@ jobs:
       - name: automerge
         uses: 'pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98'
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.AUTOMERGE_TOKEN }}'
           MERGE_LABELS: 'automerge,!work in progress'
           MERGE_REMOVE_LABELS: 'automerge'
           MERGE_METHOD: 'rebase'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -32,5 +32,5 @@ jobs:
           MERGE_FORKS: 'false'
           MERGE_RETRIES: '6'
           MERGE_RETRY_SLEEP: '10000'
-          UPDATE_LABELS: ''
+          UPDATE_LABELS: 'autoupdate'
           UPDATE_METHOD: 'rebase'


### PR DESCRIPTION
- Use different GitHub token for automege updates (should fix issues with PR builds not running on update force pushes)
- Use a separate label to enable autoupdate of PRs
