### PR TITLE
🐛 Actually fix export forwarding for test API"

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -3,9 +3,8 @@
     [
       "@babel/preset-env",
       {
-        "targets": {
-          "node": "12"
-        }
+        "targets": {"node": "12"},
+        "modules": "commonjs"
       }
     ]
   ]

--- a/src/api/test.js
+++ b/src/api/test.js
@@ -1,1 +1,1 @@
-module.exports = require('ts-jest/utils')
+export * from 'ts-jest/utils'


### PR DESCRIPTION
- Use ESM `*` to forward ts-jest exports (fixes `api/test`)
- Explicitly transpile to CommonJS to support aforementioned export

