### PR TITLE
🐛 Fix TypeScript build (yet another test API fix)

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,8 +5,8 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "declaration": true,
-    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
     "outDir": "../dist",
     "rootDir": "."
   }


### PR DESCRIPTION
The TypeScript compiler output was overwriting Babel's output which was
breaking... you guessed it, the fucking `api/test` entrypoint. This
should. fix. it. for. real.
