### PR TITLE
🔧 Migrate Husky configuration + documentation to 6+

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+node src commit-msg

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+node src pre-commit

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Automates pair commits with git-duet
+# See: https://github.com/git-duet/git-duet/#co-authored-by-trailer-support
+
+if [ $(git help -a | grep duet-prepare-msg) ]; then
+  exec git duet-prepare-commit-msg "$@"
+fi

--- a/README.md
+++ b/README.md
@@ -205,28 +205,34 @@ should work with other solutions as well.
 
 #### Husky Example
 
+> ℹ️ See [Husky Documentation](https://typicode.github.io/husky/#/?id=usage) for
+> more information
+
 1. Install Husky
 
-> ⚠️ We're sticking with Husky 4 for now as 5+ has licensing restrictions for
-> commercial projects and significantly changes how hooks are configured
+   ```bash
+   yarn add -D husky
+   ```
 
-```sh
-yarn add -D 'husky@^4.3.8'
-```
+2. Add `prepare` script
 
-2. Configure hooks in `package.json`
+   ```bash
+   npm set-script prepare "husky install"
+   ```
 
-```json
-{
-  "name": "my-package",
-  "husky": {
-    "hooks": {
-      "pre-commit": "hover-scripts pre-commit",
-      "commit-msg": "hover-scripts commit-msg"
-    }
-  }
-}
-```
+3. Create hooks
+
+   i. 📂 **.husky/pre-commit**
+
+   ```bash
+   yarn husky add .husky/pre-commit "yarn hover-scripts pre-commit"
+   ```
+
+   ii. 📂 **.husky/commit-msg**
+
+   ```bash
+   yarn husky add .husky/commit-msg "yarn hover-scripts commit-msg"
+   ```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -24,13 +24,8 @@
     "start:types": "tsc -b -w --preserveWatchOutput src/",
     "test": "node src test",
     "test:update": "node src test --updateSnapshot",
-    "validate": "node src validate"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "node src pre-commit",
-      "commit-msg": "node src commit-msg"
-    }
+    "validate": "node src validate",
+    "prepare": "husky install"
   },
   "files": [
     "api",


### PR DESCRIPTION
- Migrate Husky configuration to 7.0 (Dependabot already upgraded it)
- Update Husky instructions in `README.md` for Husky 6+

#### Additional
- Add `prepare-commit-msg` hook to optionally support [git-duet](https://github.com/git-duet/git-duet)
