### PR TITLE
✨ Add support for disabling DocToc with a command flag

### DIFF
--- a/lint-staged.js
+++ b/lint-staged.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/config/lintstagedrc')

--- a/lint-staged/index.js
+++ b/lint-staged/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/config/lintstagedrc')

--- a/lint-staged/no-toc.js
+++ b/lint-staged/no-toc.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/config/lintstagedrc-no-toc')

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.6",
     "@babel/preset-env": "^7.14.7",
+    "@types/cross-spawn": "^6.0.2",
     "babel-jest": "^27.0.6",
     "eslint-config-kentcdodds": "^19.1.0",
     "husky": "^7.0.1",

--- a/src/config/helpers/build-lint-staged.js
+++ b/src/config/helpers/build-lint-staged.js
@@ -18,8 +18,8 @@ const formatGlob =
 const lintGlob = `*.+(${sourceExtensions.join('|')})`
 const testGlob = `*.+(${sourceExtensions.reverse().join('|')})`
 
-const buildConfig = (testCommand = defaultTestCommand) => ({
-  [readmeGlob]: [`${doctoc} --maxlevel 4 --notitle`],
+const buildConfig = (toc = true, testCommand = defaultTestCommand) => ({
+  ...(toc ? {[readmeGlob]: [`${doctoc} --maxlevel 4 --notitle`]} : {}),
   [formatGlob]: [`${hoverScripts} format`],
   [lintGlob]: [`${hoverScripts} lint`],
   [testGlob]: [testCommand],

--- a/src/config/lintstagedrc-no-toc.js
+++ b/src/config/lintstagedrc-no-toc.js
@@ -1,0 +1,3 @@
+const {buildConfig} = require('./helpers/build-lint-staged')
+
+module.exports = buildConfig(false)

--- a/src/scripts/__tests__/__snapshots__/pre-commit.js.snap
+++ b/src/scripts/__tests__/__snapshots__/pre-commit.js.snap
@@ -7,6 +7,34 @@ Array [
 ]
 `;
 
+exports[`pre-commit disables DocToc and forwards args 1`] = `
+Array [
+  lint-staged --config .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json --verbose --some-other-arg,
+  npm run validate,
+]
+`;
+
+exports[`pre-commit disables DocToc and forwards args 2`] = `
+Array [
+  .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
+  {"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["./src/index.js test --findRelatedTests"]},
+]
+`;
+
+exports[`pre-commit disables DocToc, overrides built-in test command, and forwards args 1`] = `
+Array [
+  lint-staged --config .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json --verbose --some-other-arg,
+  npm run validate,
+]
+`;
+
+exports[`pre-commit disables DocToc, overrides built-in test command, and forwards args 2`] = `
+Array [
+  .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
+  {"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
+]
+`;
+
 exports[`pre-commit does not run validate script if it's not defined 1`] = `
 Array [
   lint-staged --config ./src/config/lintstagedrc.js,
@@ -83,24 +111,10 @@ Array [
 ]
 `;
 
-exports[`pre-commit overrides built-in test command with --testCommand 2`] = `
-Array [
-  .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
-]
-`;
-
 exports[`pre-commit overrides built-in test command with --testCommand and forwards args 1`] = `
 Array [
   lint-staged --config .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json --verbose,
   npm run validate,
-]
-`;
-
-exports[`pre-commit overrides built-in test command with --testCommand and forwards args 2`] = `
-Array [
-  .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"README.md":["doctoc --maxlevel 4 --notitle"],"*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["yarn test:custom --findRelatedTests foo.js"]},
 ]
 `;
 

--- a/src/scripts/pre-commit.js
+++ b/src/scripts/pre-commit.js
@@ -81,7 +81,7 @@ const lintStagedResult = spawn.sync(
   {stdio: 'inherit'},
 )
 
-if (useCustomBuiltInConfig) {
+if (useCustomBuiltInConfig && customBuiltInConfig) {
   fs.rmdirSync(path.dirname(customBuiltInConfig), {recursive: true})
 }
 
@@ -90,7 +90,7 @@ if (lintStagedResult.status === 0 && ifScript('validate')) {
     stdio: 'inherit',
   })
 
-  process.exit(validateResult.status)
+  process.exit(validateResult.status ?? 0)
 } else {
-  process.exit(lintStagedResult.status)
+  process.exit(lintStagedResult.status ?? 0)
 }

--- a/src/scripts/pre-commit.js
+++ b/src/scripts/pre-commit.js
@@ -7,13 +7,13 @@ const {
   hasPkgProp,
   hasFile,
   ifScript,
+  relative,
   resolveBin,
   getPkgName,
 } = require('../utils')
 const {buildConfig} = require('../config/helpers/build-lint-staged')
 
-const here = p => path.join(__dirname, p)
-const hereRelative = p => here(p).replace(process.cwd(), '.')
+const hereRelative = relative(__dirname)
 
 const args = process.argv.slice(2)
 const {argv: parsedArgs, aliases} = yargsParser.detailed(args)

--- a/src/scripts/pre-commit.js
+++ b/src/scripts/pre-commit.js
@@ -4,19 +4,20 @@ const os = require('os')
 const spawn = require('cross-spawn')
 const yargsParser = require('yargs-parser')
 const {
-  hasPkgProp,
+  getPkgName,
   hasFile,
+  hasPkgProp,
   ifScript,
   relative,
   resolveBin,
-  getPkgName,
+  stripArgument,
 } = require('../utils')
 const {buildConfig} = require('../config/helpers/build-lint-staged')
 
 const hereRelative = relative(__dirname)
 
 const args = process.argv.slice(2)
-const {argv: parsedArgs, aliases} = yargsParser.detailed(args)
+const {argv: parsedArgs} = yargsParser.detailed(args)
 
 /**
  * Generate a temporary copy of the built-in lint-staged
@@ -47,15 +48,11 @@ if (parsedArgs.config && parsedArgs.testCommand) {
 
 // Don't forward `--testCommand` or `--test-command`
 // flags through to `lint-staged` (yes, this is gross)
-const testCommandIndex = args.findIndex(
-  a =>
-    a === '--testCommand' ||
-    (aliases.testCommand && aliases.testCommand.includes(a.replace(/^--/, ''))),
+const argsToForward = stripArgument(
+  args,
+  ['--test-command', '--testCommand'],
+  2,
 )
-const argsToForward = [...args]
-if (testCommandIndex >= 0) {
-  argsToForward.splice(testCommandIndex, 2)
-}
 
 const useCustomBuiltInConfig = !!parsedArgs.testCommand
 const customBuiltInConfig = useCustomBuiltInConfig

--- a/src/utils.js
+++ b/src/utils.js
@@ -163,6 +163,25 @@ function hasLocalConfig(moduleName, searchOptions = {}) {
 }
 
 /**
+ * Strip an argument and it's values from arguments forwarded to lint-staged
+ *
+ * @param {any[]} from arguments to strip argument(s) from, e.g: `process.argv`
+ * @param {string[]} argument array of argument aliases, e.g: `['--foo-bar', '--fooBar']
+ * @param {number} length number arguments to strip, i.e: `--arg value` = 2
+ */
+const stripArgument = (from, argument, length = 1) => {
+  const index = from.findIndex(a => argument.includes(a))
+
+  if (index < 0) return from
+
+  const stripped = [...from]
+
+  stripped.splice(index, length)
+
+  return stripped
+}
+
+/**
  * Get function that converts relative paths to absolute
  *
  * @param {string} dirname `__dirname`
@@ -197,6 +216,7 @@ module.exports = {
   relative,
   resolveBin,
   resolveHoverScripts,
+  stripArgument,
   uniq,
   writeExtraEntry,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -162,6 +162,20 @@ function hasLocalConfig(moduleName, searchOptions = {}) {
   return result !== null
 }
 
+/**
+ * Get function that converts relative paths to absolute
+ *
+ * @param {string} dirname `__dirname`
+ */
+const relative =
+  dirname =>
+  /**
+   *
+   * @param {string} p relative path
+   */
+  p =>
+    path.join(dirname, p).replace(process.cwd(), '.')
+
 module.exports = {
   appDirectory,
   fromRoot,
@@ -180,6 +194,7 @@ module.exports = {
   ifScript,
   parseEnv,
   pkg,
+  relative,
   resolveBin,
   resolveHoverScripts,
   uniq,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,6 +1556,13 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/cross-spawn@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
+  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.3.tgz#039af35fe26bec35003e8d86d2ee9c586354348f"
@@ -1691,6 +1698,14 @@
     "@typescript-eslint/typescript-estree" "4.28.3"
     debug "^4.3.1"
 
+"@typescript-eslint/scope-manager@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz#fd3c20627cdc12933f6d98b386940d8d0ce8a991"
+  integrity sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==
+  dependencies:
+    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/visitor-keys" "4.28.1"
+
 "@typescript-eslint/scope-manager@4.28.3":
   version "4.28.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz#c32ad4491b3726db1ba34030b59ea922c214e371"
@@ -1699,10 +1714,28 @@
     "@typescript-eslint/types" "4.28.3"
     "@typescript-eslint/visitor-keys" "4.28.3"
 
+"@typescript-eslint/types@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
+  integrity sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==
+
 "@typescript-eslint/types@4.28.3":
   version "4.28.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.3.tgz#8fffd436a3bada422c2c1da56060a0566a9506c7"
   integrity sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==
+
+"@typescript-eslint/typescript-estree@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz#af882ae41740d1f268e38b4d0fad21e7e8d86a81"
+  integrity sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==
+  dependencies:
+    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/visitor-keys" "4.28.1"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.28.3":
   version "4.28.3"
@@ -1716,6 +1749,14 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
+  integrity sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==
+  dependencies:
+    "@typescript-eslint/types" "4.28.1"
+    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.28.3":
   version "4.28.3"


### PR DESCRIPTION
- Add support for `--no-toc` flag in `pre-commit` script that disables DocToc.
- Add `/lint-staged/no-toc` variant of *lint-staged* configuration

#### Additional
- Add *cross-spawn* types
- Pull out relative path helper function `const hereRelative = relative(__dirname)`
- Pull out helper function for stripping arguments
- Fix type checking warnings in `scripts/pre-commit`
