### PR TITLE
🐛 Ensure ts-jest preset is resolved

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,7 @@ module.exports = {
       tsconfig: './src/tsconfig.json',
       diagnostics: {
         warnOnly: true,
-        exclude: ['src/scripts/**/*.js', 'src/config/**/*.js'],
+        exclude: ['**/*'],
       },
     },
   },

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -1,6 +1,7 @@
 /** @typedef {import('@jest/types').Config.InitialOptions} JestConfig */
 
 const {ifAnyDep, hasAnyDep, hasFile, fromRoot} = require('../utils')
+const {jsWithTs: preset} = require('ts-jest/presets')
 
 const ignores = [
   '/node_modules/',
@@ -59,7 +60,8 @@ const jestConfig = {
 }
 
 if (hasAnyDep('ts-jest') || hasFile('tsconfig.json')) {
-  jestConfig.preset = 'ts-jest/presets/js-with-ts'
+  Object.assign(jestConfig, preset)
+
   jestConfig.globals['ts-jest'] = {
     diagnostics: {
       warnOnly: true,


### PR DESCRIPTION
Because we're encapsulating the `ts-jest` dependency, there are cases where a package manager won't lift `ts-jest` to the root `node_modules` directory which prevents the preset from being loaded. Importing (`require('ts-jest/presets')`) the preset ensures it will always resolve, even when the dependency is nested, e.g: `./node_modules/@hover/javascript/node_modules/ts-jest`.
