### PR TITLE
🐛 Fix lint-staged entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-react.js",
     "eslint",
     "jest.js",
-    "lint-staged.js",
+    "lint-staged",
     "prettier.js",
     "release.js",
     "tsconfig.json"


### PR DESCRIPTION
Update `files` field in `package.json` to correctly expose **@hover/javascript/lint-staged** entrypoint now that it is a folder and not just a single file.
