### PR TITLE
Revert ts-jest preset change

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -1,7 +1,6 @@
 /** @typedef {import('@jest/types').Config.InitialOptions} JestConfig */
 
 const {ifAnyDep, hasAnyDep, hasFile, fromRoot} = require('../utils')
-const {jsWithTs: preset} = require('ts-jest/presets')
 
 const ignores = [
   '/node_modules/',
@@ -60,8 +59,7 @@ const jestConfig = {
 }
 
 if (hasAnyDep('ts-jest') || hasFile('tsconfig.json')) {
-  Object.assign(jestConfig, preset)
-
+  jestConfig.preset = 'ts-jest/presets/js-with-ts'
   jestConfig.globals['ts-jest'] = {
     diagnostics: {
       warnOnly: true,


### PR DESCRIPTION
This reverts commit ea4489a9fe4cc946b28978d8bc7ce3131eef29d8.Reverts hoverinc/hover-javascript#511

The fix was intended to make the `jest.config.js` this package exports more resilient to `ts-jest` being installed in a nested `./node_modules` location, but it doesn't work and furthermore it breaks the `jest.config.js`.