### PR TITLE
🐛 Resolve ESLint plugins relative to @hover/javascript

### DIFF
--- a/src/config/helpers/build-eslint.js
+++ b/src/config/helpers/build-eslint.js
@@ -3,7 +3,7 @@ const {
 } = require('eslint-config-airbnb-typescript/lib/shared')
 
 const {hasAnyDep} = require('../../utils')
-const {testMatch} = require('../jest.config')
+const {testMatch} = require('../helpers/test-match')
 
 const withBaseConfig = base => variant =>
   require.resolve(base + (variant ? `/${variant}` : ''))

--- a/src/config/helpers/test-match.js
+++ b/src/config/helpers/test-match.js
@@ -1,0 +1,22 @@
+const toGlob = extensions => `*.+(${extensions.join('|')})`
+
+const testMatchExtensions = ['js', 'jsx', 'ts', 'tsx']
+const testMatchGlob = toGlob(testMatchExtensions)
+const testMatchSuffixGlob = toGlob(
+  testMatchExtensions.map(extension => 'test.'.concat(extension)),
+)
+
+const testMatch = [
+  `**/__tests__/**/${testMatchGlob}`,
+  `test/**/${testMatchGlob}`,
+  `test/**/${testMatchSuffixGlob}`,
+  `e2e/**/${testMatchSuffixGlob}`,
+  `**/${testMatchSuffixGlob}`,
+]
+
+module.exports = {
+  testMatchExtensions,
+  testMatchGlob,
+  testMatchSuffixGlob,
+  testMatch,
+}

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -4,6 +4,12 @@ const {jsWithTs: preset} = require('ts-jest/presets')
 
 const {ifAnyDep, hasAnyDep, hasFile, fromRoot} = require('../utils')
 
+const {
+  testMatch,
+  testMatchGlob,
+  testMatchExtensions,
+} = require('./helpers/test-match')
+
 const ignores = [
   '/node_modules/',
   '/__fixtures__/',
@@ -13,13 +19,6 @@ const ignores = [
   '__mocks__',
 ]
 
-const toGlob = extensions => `*.+(${extensions.join('|')})`
-const testMatchExtensions = ['js', 'jsx', 'ts', 'tsx']
-const testMatchGlob = toGlob(testMatchExtensions)
-const testMatchSuffixGlob = toGlob(
-  testMatchExtensions.map(extension => 'test.'.concat(extension)),
-)
-
 /** @type JestConfig */
 const jestConfig = {
   roots: [fromRoot('.')],
@@ -27,13 +26,7 @@ const jestConfig = {
   testURL: 'http://localhost',
   moduleFileExtensions: testMatchExtensions.concat('json'),
   collectCoverageFrom: [`**/${testMatchGlob}`],
-  testMatch: [
-    `**/__tests__/**/${testMatchGlob}`,
-    `test/**/${testMatchGlob}`,
-    `test/**/${testMatchSuffixGlob}`,
-    `e2e/**/${testMatchSuffixGlob}`,
-    `**/${testMatchSuffixGlob}`,
-  ],
+  testMatch,
   testPathIgnorePatterns: [...ignores, '<rootDir>/dist'],
   coveragePathIgnorePatterns: [
     ...ignores,

--- a/src/run-script.js
+++ b/src/run-script.js
@@ -18,6 +18,7 @@ if (script) {
       s
         .replace(scriptsPath, '')
         .replace(/__tests__/, '')
+        .replace(/__mocks__/, '')
         .replace(/\.js$/, ''),
     )
     .filter(Boolean)

--- a/src/scripts/__mocks__/@hover/javascript/eslint.js
+++ b/src/scripts/__mocks__/@hover/javascript/eslint.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/src/scripts/__tests__/__snapshots__/lint.js.snap
+++ b/src/scripts/__tests__/__snapshots__/lint.js.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`lint --no-cache will disable caching 1`] = `eslint --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --ext .js,.jsx,.ts,.tsx --no-cache .`;
+exports[`lint --no-cache will disable caching 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --ext .js,.jsx,.ts,.tsx --no-cache .`;
 
-exports[`lint calls eslint CLI with default args 1`] = `eslint --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
+exports[`lint calls eslint CLI with default args 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --config ./src/config/eslintrc.js --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint does not use built-in config with .eslintrc file 1`] = `eslint --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
+exports[`lint does not use built-in config with .eslintrc file 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint does not use built-in config with .eslintrc.js file 1`] = `eslint --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
+exports[`lint does not use built-in config with .eslintrc.js file 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint does not use built-in config with --config 1`] = `eslint --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx --config ./custom-config.js .`;
+exports[`lint does not use built-in config with --config 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx --config ./custom-config.js .`;
 
-exports[`lint does not use built-in config with eslintConfig pkg prop 1`] = `eslint --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
+exports[`lint does not use built-in config with eslintConfig pkg prop 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --ignore-path ./src/config/eslintignore --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint does not use built-in ignore with .eslintignore file 1`] = `eslint --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
+exports[`lint does not use built-in ignore with .eslintignore file 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint does not use built-in ignore with --ignore-path 1`] = `eslint --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx --ignore-path ./my-ignore .`;
+exports[`lint does not use built-in ignore with --ignore-path 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx --ignore-path ./my-ignore .`;
 
-exports[`lint does not use built-in ignore with eslintIgnore pkg prop 1`] = `eslint --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;
+exports[`lint does not use built-in ignore with eslintIgnore pkg prop 1`] = `eslint --resolve-plugins-relative-to <PROJECT_ROOT>/src/scripts/__mocks__/@hover/javascript --config ./src/config/eslintrc.js --cache --cache-location <PROJECT_ROOT>/node_modules/.cache/.eslintcache --ext .js,.jsx,.ts,.tsx .`;

--- a/src/scripts/lint.js
+++ b/src/scripts/lint.js
@@ -15,6 +15,18 @@ const useBuiltinConfig =
   !hasFile('.eslintrc.json') &&
   !hasPkgProp('eslintConfig')
 
+let resolved
+
+try {
+  resolved = require.resolve('@hover/javascript/eslint')
+} catch {
+  // This is only here for internal usage as the above will not resolve
+}
+
+const resolvePlugins = resolved
+  ? ['--resolve-plugins-relative-to', path.dirname(resolved)]
+  : []
+
 const config = useBuiltinConfig
   ? ['--config', hereRelative('../config/eslintrc.js')]
   : []
@@ -44,7 +56,15 @@ const filesToApply = filesGiven ? [] : ['.']
 
 const result = spawn.sync(
   resolveBin('eslint'),
-  [...config, ...ignore, ...cache, ...extensions, ...args, ...filesToApply],
+  [
+    ...resolvePlugins,
+    ...config,
+    ...ignore,
+    ...cache,
+    ...extensions,
+    ...args,
+    ...filesToApply,
+  ],
   {stdio: 'inherit'},
 )
 


### PR DESCRIPTION
Resolve ESLint plugins relative to **@hover/javascript** installation. This makes the ESLint configuration handle cases where package managers nest the ESLint dependencies in `node_modules/@hover/javascript/node_modules`.

#### Additional
- Move test match configuration into common helper
