### PR TITLE
🐛 Include Yaml-based ESLint configs

### DIFF
--- a/src/scripts/lint.js
+++ b/src/scripts/lint.js
@@ -13,6 +13,8 @@ const useBuiltinConfig =
   !hasFile('.eslintrc') &&
   !hasFile('.eslintrc.js') &&
   !hasFile('.eslintrc.json') &&
+  !hasFile('.eslintrc.yml') &&
+  !hasFile('.eslintrc.yaml') &&
   !hasPkgProp('eslintConfig')
 
 let resolved


### PR DESCRIPTION
Lood for `.eslintrc.yml` and `.eslintrc.yaml` when determining whether to use built-in ESLint configuration.
