### PR TITLE
✨ Report with GitHub actions reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "glob": "^7.2.0",
     "is-ci": "^3.0.0",
     "jest": "^27.3.1",
+    "jest-github-actions-reporter": "^1.0.3",
     "jest-watch-typeahead": "^1.0.0",
     "lint-staged": "^11.1.2",
     "lodash.has": "^4.5.2",

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -28,6 +28,7 @@ const jestConfig = {
   collectCoverageFrom: [`**/${testMatchGlob}`],
   testMatch,
   testPathIgnorePatterns: [...ignores, '<rootDir>/dist'],
+  testLocationInResults: true,
   coveragePathIgnorePatterns: [
     ...ignores,
     'src/(umd|cjs|esm)-entry.js$',

--- a/src/scripts/__tests__/__snapshots__/test.js.snap
+++ b/src/scripts/__tests__/__snapshots__/test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`test calls jest.run with default args 1`] = `--config {"builtInConfig":true} --watch`;
 
+exports[`test configures GitHub actions reporter on GitHub actions 1`] = `--config {"builtInConfig":true} --reporters=default --reporters=jest-github-actions-reporter`;
+
 exports[`test does not watch --updateSnapshot 1`] = `--config {"builtInConfig":true} --updateSnapshot`;
 
 exports[`test does not watch on CI 1`] = `--config {"builtInConfig":true}`;

--- a/src/scripts/__tests__/test.js
+++ b/src/scripts/__tests__/test.js
@@ -69,6 +69,10 @@ cases(
     'does not watch on SCRIPTS_PRE-COMMIT': {
       env: {'SCRIPTS_PRE-COMMIT': true},
     },
+    'configures GitHub actions reporter on GitHub actions': {
+      ci: true,
+      env: {GITHUB_WORKFLOW: 'test.yml'},
+    },
     'does not watch with --no-watch': {
       args: ['--no-watch'],
     },

--- a/src/scripts/test.js
+++ b/src/scripts/test.js
@@ -22,5 +22,10 @@ const config =
     ? ['--config', JSON.stringify(require('../config/jest.config'))]
     : []
 
+const reporters =
+  isCI && process.env.GITHUB_WORKFLOW
+    ? ['--reporters=default', '--reporters=jest-github-actions-reporter']
+    : []
+
 // eslint-disable-next-line jest/no-jest-import
-require('jest').run([...config, ...watch, ...args])
+require('jest').run([...config, ...watch, ...reporters, ...args])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,20 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.2.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.6.0.tgz#0568e47039bfb6a9170393a73f3b7eb3b22462cb"
+  integrity sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==
+  dependencies:
+    "@actions/http-client" "^1.0.11"
+
+"@actions/http-client@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.11.tgz#c58b12e9aa8b159ee39e7dd6cbd0e91d905633c0"
+  integrity sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==
+  dependencies:
+    tunnel "0.0.6"
+
 "@babel/cli@^7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.15.7.tgz#62658abedb786d09c1f70229224b11a65440d7a1"
@@ -4612,6 +4626,13 @@ jest-get-type@^27.3.1:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.3.1.tgz#a8a2b0a12b50169773099eee60a0e6dd11423eff"
   integrity sha512-+Ilqi8hgHSAdhlQ3s12CAVNd8H96ZkQBfYoXmArzZnOfAtVAJEiPDBirjByEblvG/4LPJmkL+nBqPO3A1YJAEg==
 
+jest-github-actions-reporter@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/jest-github-actions-reporter/-/jest-github-actions-reporter-1.0.3.tgz#6aa2b3a6599352e1043bbe42628a7f73a1ce48c2"
+  integrity sha512-IwLAKLSWLN8ZVfcfEEv6rfeWb78wKDeOhvOmH9KKXayKsKLSCwceopBcB+KUtwxfB5wYnT8Y9s2eZ+WdhA5yng==
+  dependencies:
+    "@actions/core" "^1.2.0"
+
 jest-haste-map@^27.2.4:
   version "27.2.4"
   resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.2.4.tgz#f8974807bedf07348ca9fd24e5861ab7c8e61aba"
@@ -6986,6 +7007,11 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Configure Jest with GitHub actions reporter when on running in the context of GitHub actions.

- Add **jest-github-actions-reporter**
- 🎨 Give test some room to breath, mock `env` entirely
- Enable `testLocationInResults`
