### PR TITLE
✨ Add strict React ESLint configuration

### DIFF
--- a/eslint/react-strict.js
+++ b/eslint/react-strict.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/config/eslintrc-react-strict')

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import slash from 'slash'
 import cases from 'jest-in-case'
-import {unquoteSerializer} from '../scripts/__tests__/helpers/serializers'
+import {unquoteSerializer} from '../test/helpers/serializers'
 
 const projectRoot = path.join(__dirname, '../../')
 

--- a/src/config/__tests__/__snapshots__/eslintrc.js.snap
+++ b/src/config/__tests__/__snapshots__/eslintrc.js.snap
@@ -261,6 +261,26 @@ Object {
 }
 `;
 
+exports[`Strict ESLint React configuration 1`] = `
+Object {
+  "rules": Object {
+    "react/function-component-definition": Array [
+      "error",
+      Object {
+        "namedComponents": "arrow-function",
+        "unnamedComponents": "arrow-function",
+      },
+    ],
+    "react/jsx-sort-props": Array [
+      "error",
+      Object {
+        "reservedFirst": false,
+      },
+    ],
+  },
+}
+`;
+
 exports[`Strict ESLint configuration 1`] = `
 Object {
   "rules": Object {

--- a/src/config/__tests__/__snapshots__/eslintrc.js.snap
+++ b/src/config/__tests__/__snapshots__/eslintrc.js.snap
@@ -127,6 +127,7 @@ Object {
       },
     ],
     "prettier/prettier": "error",
+    "react/function-component-definition": "off",
     "react/jsx-props-no-spreading": "off",
     "react/prop-types": "error",
   },

--- a/src/config/__tests__/__snapshots__/eslintrc.js.snap
+++ b/src/config/__tests__/__snapshots__/eslintrc.js.snap
@@ -127,6 +127,7 @@ Object {
       },
     ],
     "prettier/prettier": "error",
+    "react/jsx-props-no-spreading": "off",
     "react/prop-types": "error",
   },
 }

--- a/src/config/__tests__/__snapshots__/eslintrc.js.snap
+++ b/src/config/__tests__/__snapshots__/eslintrc.js.snap
@@ -1,0 +1,303 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ESLint React configuration 1`] = `
+Object {
+  "extends": Array [
+    <PROJECT_ROOT>/node_modules/eslint-config-airbnb/index.js,
+    <PROJECT_ROOT>/node_modules/eslint-config-airbnb-typescript/index.js,
+    "plugin:jest/recommended",
+    <PROJECT_ROOT>/node_modules/eslint-config-prettier/index.js,
+    "plugin:react-hooks/recommended",
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      ],
+      "files": Array [
+        "**/*.ts?(x)",
+      ],
+      "rules": Object {
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/no-implied-eval": "error",
+        "@typescript-eslint/no-throw-literal": "error",
+        "@typescript-eslint/return-await": "error",
+        "no-implied-eval": "off",
+        "no-throw-literal": "off",
+        "react/prop-types": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/__tests__/**/*.+(js|jsx|ts|tsx)",
+        "test/**/*.+(js|jsx|ts|tsx)",
+        "test/**/*.+(test.js|test.jsx|test.ts|test.tsx)",
+        "e2e/**/*.+(test.js|test.jsx|test.ts|test.tsx)",
+        "**/*.+(test.js|test.jsx|test.ts|test.tsx)",
+      ],
+      "rules": Object {
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "no-empty": Array [
+          "error",
+          Object {
+            "allowEmptyCatch": true,
+          },
+        ],
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*/__tests__/helpers/**/*",
+        "**/*/__tests__/utils/**/*",
+      ],
+      "rules": Object {
+        "jest/no-export": "off",
+      },
+    },
+  ],
+  "plugins": Array [
+    "prettier",
+    "jest",
+    "react-hooks",
+  ],
+  "rules": Object {
+    "@typescript-eslint/dot-notation": "off",
+    "@typescript-eslint/no-implied-eval": "off",
+    "@typescript-eslint/no-throw-literal": "off",
+    "@typescript-eslint/return-await": "off",
+    "import/no-extraneous-dependencies": Array [
+      "error",
+      Object {
+        "devDependencies": Array [
+          "test/**",
+          "tests/**",
+          "spec/**",
+          "**/__tests__/**",
+          "**/__mocks__/**",
+          "test.{js,jsx}",
+          "test.{ts,tsx}",
+          "test-*.{js,jsx}",
+          "test-*.{ts,tsx}",
+          "**/*{.,_}{test,spec}.{js,jsx}",
+          "**/*{.,_}{test,spec}.{ts,tsx}",
+          "**/jest.config.js",
+          "**/jest.config.ts",
+          "**/jest.setup.js",
+          "**/jest.setup.ts",
+          "**/vue.config.js",
+          "**/vue.config.ts",
+          "**/webpack.config.js",
+          "**/webpack.config.ts",
+          "**/webpack.config.*.js",
+          "**/webpack.config.*.ts",
+          "**/rollup.config.js",
+          "**/rollup.config.ts",
+          "**/rollup.config.*.js",
+          "**/rollup.config.*.ts",
+          "**/gulpfile.js",
+          "**/gulpfile.ts",
+          "**/gulpfile.*.js",
+          "**/gulpfile.*.ts",
+          "**/Gruntfile{,.js}",
+          "**/Gruntfile{,.ts}",
+          "**/protractor.conf.js",
+          "**/protractor.conf.ts",
+          "**/protractor.conf.*.js",
+          "**/protractor.conf.*.ts",
+          "**/karma.conf.js",
+          "**/karma.conf.ts",
+          "**/.eslintrc.js",
+          "**/.eslintrc.ts",
+          "jest/**",
+          "test/**",
+          "e2e/**",
+          "**/*.config.{js,cjs,ts}",
+        ],
+        "optionalDependencies": false,
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "no-implied-eval": "error",
+    "no-throw-literal": "error",
+    "no-void": Array [
+      "error",
+      Object {
+        "allowAsStatement": true,
+      },
+    ],
+    "prettier/prettier": "error",
+    "react/prop-types": "error",
+  },
+}
+`;
+
+exports[`ESLint configuration 1`] = `
+Object {
+  "extends": Array [
+    <PROJECT_ROOT>/node_modules/eslint-config-airbnb-base/index.js,
+    <PROJECT_ROOT>/node_modules/eslint-config-airbnb-typescript/base.js,
+    "plugin:jest/recommended",
+    <PROJECT_ROOT>/node_modules/eslint-config-prettier/index.js,
+  ],
+  "overrides": Array [
+    Object {
+      "extends": Array [
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+      ],
+      "files": Array [
+        "**/*.ts?(x)",
+      ],
+      "rules": Object {
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/no-implied-eval": "error",
+        "@typescript-eslint/no-throw-literal": "error",
+        "@typescript-eslint/return-await": "error",
+        "no-implied-eval": "off",
+        "no-throw-literal": "off",
+      },
+    },
+    Object {
+      "files": Array [
+        "**/__tests__/**/*.+(js|jsx|ts|tsx)",
+        "test/**/*.+(js|jsx|ts|tsx)",
+        "test/**/*.+(test.js|test.jsx|test.ts|test.tsx)",
+        "e2e/**/*.+(test.js|test.jsx|test.ts|test.tsx)",
+        "**/*.+(test.js|test.jsx|test.ts|test.tsx)",
+      ],
+      "rules": Object {
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "no-empty": Array [
+          "error",
+          Object {
+            "allowEmptyCatch": true,
+          },
+        ],
+      },
+    },
+    Object {
+      "files": Array [
+        "**/*/__tests__/helpers/**/*",
+        "**/*/__tests__/utils/**/*",
+      ],
+      "rules": Object {
+        "jest/no-export": "off",
+      },
+    },
+  ],
+  "plugins": Array [
+    "prettier",
+    "jest",
+  ],
+  "rules": Object {
+    "@typescript-eslint/dot-notation": "off",
+    "@typescript-eslint/no-implied-eval": "off",
+    "@typescript-eslint/no-throw-literal": "off",
+    "@typescript-eslint/return-await": "off",
+    "import/no-extraneous-dependencies": Array [
+      "error",
+      Object {
+        "devDependencies": Array [
+          "test/**",
+          "tests/**",
+          "spec/**",
+          "**/__tests__/**",
+          "**/__mocks__/**",
+          "test.{js,jsx}",
+          "test.{ts,tsx}",
+          "test-*.{js,jsx}",
+          "test-*.{ts,tsx}",
+          "**/*{.,_}{test,spec}.{js,jsx}",
+          "**/*{.,_}{test,spec}.{ts,tsx}",
+          "**/jest.config.js",
+          "**/jest.config.ts",
+          "**/jest.setup.js",
+          "**/jest.setup.ts",
+          "**/vue.config.js",
+          "**/vue.config.ts",
+          "**/webpack.config.js",
+          "**/webpack.config.ts",
+          "**/webpack.config.*.js",
+          "**/webpack.config.*.ts",
+          "**/rollup.config.js",
+          "**/rollup.config.ts",
+          "**/rollup.config.*.js",
+          "**/rollup.config.*.ts",
+          "**/gulpfile.js",
+          "**/gulpfile.ts",
+          "**/gulpfile.*.js",
+          "**/gulpfile.*.ts",
+          "**/Gruntfile{,.js}",
+          "**/Gruntfile{,.ts}",
+          "**/protractor.conf.js",
+          "**/protractor.conf.ts",
+          "**/protractor.conf.*.js",
+          "**/protractor.conf.*.ts",
+          "**/karma.conf.js",
+          "**/karma.conf.ts",
+          "**/.eslintrc.js",
+          "**/.eslintrc.ts",
+          "jest/**",
+          "test/**",
+          "e2e/**",
+          "**/*.config.{js,cjs,ts}",
+        ],
+        "optionalDependencies": false,
+      },
+    ],
+    "import/prefer-default-export": "off",
+    "no-implied-eval": "error",
+    "no-throw-literal": "error",
+    "no-void": Array [
+      "error",
+      Object {
+        "allowAsStatement": true,
+      },
+    ],
+    "prettier/prettier": "error",
+  },
+}
+`;
+
+exports[`Strict ESLint configuration 1`] = `
+Object {
+  "rules": Object {
+    "import/order": Array [
+      "error",
+      Object {
+        "alphabetize": Object {
+          "order": "asc",
+        },
+        "newlines-between": "always",
+        "pathGroups": Array [
+          Object {
+            "group": "parent",
+            "pattern": "src/**/*",
+            "position": "before",
+          },
+          Object {
+            "group": "parent",
+            "pattern": "test/**/*",
+            "position": "before",
+          },
+          Object {
+            "group": "parent",
+            "pattern": "assets/**/*",
+            "position": "before",
+          },
+        ],
+        "pathGroupsExcludedImportTypes": Array [
+          "builtin",
+        ],
+      },
+    ],
+    "sort-imports": Array [
+      "error",
+      Object {
+        "ignoreDeclarationSort": true,
+      },
+    ],
+  },
+}
+`;

--- a/src/config/__tests__/eslintrc.js
+++ b/src/config/__tests__/eslintrc.js
@@ -1,6 +1,7 @@
 import eslint from '../eslintrc'
 import eslintStrict from '../eslintrc-strict'
 import eslintReact from '../eslintrc-react'
+import eslintReactStrict from '../eslintrc-react-strict'
 
 import {
   winPathSerializer,
@@ -20,4 +21,8 @@ test('Strict ESLint configuration', () => {
 
 test('ESLint React configuration', () => {
   expect(eslintReact).toMatchSnapshot()
+})
+
+test('Strict ESLint React configuration', () => {
+  expect(eslintReactStrict).toMatchSnapshot()
 })

--- a/src/config/__tests__/eslintrc.js
+++ b/src/config/__tests__/eslintrc.js
@@ -1,0 +1,23 @@
+import eslint from '../eslintrc'
+import eslintStrict from '../eslintrc-strict'
+import eslintReact from '../eslintrc-react'
+
+import {
+  winPathSerializer,
+  relativePathSerializer,
+} from '../../test/helpers/serializers'
+
+expect.addSnapshotSerializer(winPathSerializer)
+expect.addSnapshotSerializer(relativePathSerializer)
+
+test('ESLint configuration', () => {
+  expect(eslint).toMatchSnapshot()
+})
+
+test('Strict ESLint configuration', () => {
+  expect(eslintStrict).toMatchSnapshot()
+})
+
+test('ESLint React configuration', () => {
+  expect(eslintReact).toMatchSnapshot()
+})

--- a/src/config/eslintrc-react-strict.js
+++ b/src/config/eslintrc-react-strict.js
@@ -1,0 +1,12 @@
+module.exports = {
+  rules: {
+    'react/jsx-sort-props': ['error', {reservedFirst: false}],
+    'react/function-component-definition': [
+      'error',
+      {
+        namedComponents: 'arrow-function',
+        unnamedComponents: 'arrow-function',
+      },
+    ],
+  },
+}

--- a/src/config/eslintrc-react.js
+++ b/src/config/eslintrc-react.js
@@ -1,3 +1,11 @@
 const {buildConfig} = require('./helpers/build-eslint')
 
-module.exports = buildConfig({withReact: true})
+const {rules, ...rest} = buildConfig({withReact: true})
+
+module.exports = {
+  rules: {
+    'react/jsx-props-no-spreading': 'off',
+    ...rules,
+  },
+  ...rest,
+}

--- a/src/config/eslintrc-react.js
+++ b/src/config/eslintrc-react.js
@@ -5,6 +5,7 @@ const {rules, ...rest} = buildConfig({withReact: true})
 module.exports = {
   rules: {
     'react/jsx-props-no-spreading': 'off',
+    'react/function-component-definition': 'off',
     ...rules,
   },
   ...rest,

--- a/src/scripts/__tests__/ci-after-success.js
+++ b/src/scripts/__tests__/ci-after-success.js
@@ -1,5 +1,5 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer} from './helpers/serializers'
+import {unquoteSerializer} from '../../test/helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 
@@ -97,26 +97,29 @@ cases(
     'does not do the autorelease script when the version is different': {
       version: '1.2.3',
     },
-    'configures semantic release with internal configuration when no local configuration exists': {
-      hasCoverageDir: false,
-      hasLocalConfig: false,
-    },
+    'configures semantic release with internal configuration when no local configuration exists':
+      {
+        hasCoverageDir: false,
+        hasLocalConfig: false,
+      },
     'does not do the codecov script when there is no coverage directory': {
       hasCoverageDir: false,
     },
     'does not do the codecov script when opted out': {
       isOptedOutOfCoverage: true,
     },
-    'does not do autorelease script when running on travis but in a pull request': {
-      env: {
-        TRAVIS: 'true',
-        TRAVIS_BRANCH: 'main',
-        TRAVIS_PULL_REQUEST: 'true',
+    'does not do autorelease script when running on travis but in a pull request':
+      {
+        env: {
+          TRAVIS: 'true',
+          TRAVIS_BRANCH: 'main',
+          TRAVIS_PULL_REQUEST: 'true',
+        },
       },
-    },
-    'does not run either script when no coverage dir and not the right version': {
-      hasCoverageDir: false,
-      version: '1.2.3',
-    },
+    'does not run either script when no coverage dir and not the right version':
+      {
+        hasCoverageDir: false,
+        version: '1.2.3',
+      },
   },
 )

--- a/src/scripts/__tests__/commit-msg.js
+++ b/src/scripts/__tests__/commit-msg.js
@@ -1,5 +1,8 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer, winPathSerializer} from './helpers/serializers'
+import {
+  unquoteSerializer,
+  winPathSerializer,
+} from '../../test/helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)
@@ -62,8 +65,9 @@ cases(
     'adds env flag with HUSKY_GIT_PARAMS when available': {
       env: {HUSKY_GIT_PARAMS: 'husky-git-params'},
     },
-    'defaults to `--edit` when no args are passed and HUSKY_GIT_PARAMS is not available': {
-      env: {HUSKY_GIT_PARAMS: undefined, args: []},
-    },
+    'defaults to `--edit` when no args are passed and HUSKY_GIT_PARAMS is not available':
+      {
+        env: {HUSKY_GIT_PARAMS: undefined, args: []},
+      },
   },
 )

--- a/src/scripts/__tests__/commit.js
+++ b/src/scripts/__tests__/commit.js
@@ -3,7 +3,7 @@ import {
   unquoteSerializer,
   winPathSerializer,
   relativePathSerializer,
-} from './helpers/serializers'
+} from '../../test/helpers/serializers'
 
 jest.mock('commitizen/dist/cli/git-cz')
 

--- a/src/scripts/__tests__/format.js
+++ b/src/scripts/__tests__/format.js
@@ -1,5 +1,8 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer, winPathSerializer} from './helpers/serializers'
+import {
+  unquoteSerializer,
+  winPathSerializer,
+} from '../../test/helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)

--- a/src/scripts/__tests__/lint.js
+++ b/src/scripts/__tests__/lint.js
@@ -3,7 +3,7 @@ import {
   unquoteSerializer,
   winPathSerializer,
   relativePathSerializer,
-} from './helpers/serializers'
+} from '../../test/helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)

--- a/src/scripts/__tests__/pre-commit.js
+++ b/src/scripts/__tests__/pre-commit.js
@@ -1,6 +1,9 @@
 import path from 'path'
 import cases from 'jest-in-case'
-import {unquoteSerializer, winPathSerializer} from './helpers/serializers'
+import {
+  unquoteSerializer,
+  winPathSerializer,
+} from '../../test/helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)

--- a/src/scripts/__tests__/test.js
+++ b/src/scripts/__tests__/test.js
@@ -1,5 +1,5 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer} from './helpers/serializers'
+import {unquoteSerializer} from '../../test/helpers/serializers'
 
 jest.mock('jest', () => ({run: jest.fn()}))
 jest.mock('../../config/jest.config', () => ({builtInConfig: true}))

--- a/src/scripts/__tests__/validate.js
+++ b/src/scripts/__tests__/validate.js
@@ -1,5 +1,5 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer} from './helpers/serializers'
+import {unquoteSerializer} from '../../test/helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 

--- a/src/test/helpers/serializers.js
+++ b/src/test/helpers/serializers.js
@@ -21,5 +21,6 @@ function normalizePaths(value) {
   if (typeof value !== 'string') {
     return value
   }
+
   return slash(value.split(process.cwd()).join('<PROJECT_ROOT>'))
 }


### PR DESCRIPTION
- refactor: move serializers into dedicated test helpers directory
- test(config/eslint): add snapshot coverage for ESLint configurations
- feat(config/eslint): disable `react/jsx-props-no-spreading`
- feat(config/eslint): add strict React ESLint configuration
