### PR TITLE
🐛 Fix bin resolution for ESM tools

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -30,9 +30,12 @@ function resolveBin(modName, {executable = modName, cwd = process.cwd()} = {}) {
     // ignore _error
   }
   try {
-    const modPkgPath = require.resolve(`${modName}/package.json`)
-    const modPkgDir = path.dirname(modPkgPath)
-    const {bin} = require(modPkgPath)
+    const { packageJson: binPackage, path: modPkgDir } = readPkgUp.sync({
+      cwd: path.dirname(require.resolve(modName)),
+    })
+    
+    const {bin} = binPackage;
+    
     const binPath = typeof bin === 'string' ? bin : bin[executable]
     const fullPathToBin = path.join(modPkgDir, binPath)
     if (fullPathToBin === pathFromWhich) {


### PR DESCRIPTION
This addresses the 💥 in the `pre-commit` caused by upgrading Lint Staged to 12.x (pure ESM).

The `resolveBin` util was using `require('package-name/package.json')` to read the `bin` field of packages, but that blows up for ESM packages as an export map is required to define the package entrypoint and who's gonna add `package.json` as a package entry?
