### PR TITLE
🐛 Fix all scripts (I broke everything)

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -41,19 +41,35 @@ test('resolveHoverScripts resolves to "hover-scripts" if not in the @hover/javas
   expect(require('../utils').resolveHoverScripts()).toBe('hover-scripts')
 })
 
-test(`resolveBin resolves to the full path when it's not in $PATH`, () => {
-  expect(require('../utils').resolveBin('cross-env')).toBe(
-    require.resolve('cross-env/src/bin/cross-env').replace(process.cwd(), '.'),
-  )
-})
+describe('resolveBin', () => {
+  beforeAll(() => {
+    jest.unmock('read-pkg-up')
+  })
 
-test(`resolveBin resolves to the binary if it's in $PATH`, () => {
-  whichSyncMock.mockImplementationOnce(() =>
-    require.resolve('cross-env/src/bin/cross-env').replace(process.cwd(), '.'),
-  )
-  expect(require('../utils').resolveBin('cross-env')).toBe('cross-env')
-  expect(whichSyncMock).toHaveBeenCalledTimes(1)
-  expect(whichSyncMock).toHaveBeenCalledWith('cross-env')
+  afterAll(() => {
+    jest.mock('read-pkg-up', () => ({
+      sync: jest.fn(() => ({packageJson: {}, path: '/blah/package.json'})),
+    }))
+  })
+
+  test(`resolveBin resolves to the full path when it's not in $PATH`, () => {
+    expect(require('../utils').resolveBin('cross-env')).toBe(
+      require
+        .resolve('cross-env/src/bin/cross-env')
+        .replace(process.cwd(), '.'),
+    )
+  })
+
+  test(`resolveBin resolves to the binary if it's in $PATH`, () => {
+    whichSyncMock.mockImplementationOnce(() =>
+      require
+        .resolve('cross-env/src/bin/cross-env')
+        .replace(process.cwd(), '.'),
+    )
+    expect(require('../utils').resolveBin('cross-env')).toBe('cross-env')
+    expect(whichSyncMock).toHaveBeenCalledTimes(1)
+    expect(whichSyncMock).toHaveBeenCalledWith('cross-env')
+  })
 })
 
 describe('for windows', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,12 +30,13 @@ function resolveBin(modName, {executable = modName, cwd = process.cwd()} = {}) {
     // ignore _error
   }
   try {
-    const { packageJson: binPackage, path: modPkgDir } = readPkgUp.sync({
+    const {packageJson: binPackage, path: binPackagePath} = readPkgUp.sync({
       cwd: path.dirname(require.resolve(modName)),
     })
-    
-    const {bin} = binPackage;
-    
+
+    const modPkgDir = path.dirname(binPackagePath)
+    const {bin} = binPackage
+
     const binPath = typeof bin === 'string' ? bin : bin[executable]
     const fullPathToBin = path.join(modPkgDir, binPath)
     if (fullPathToBin === pathFromWhich) {


### PR DESCRIPTION
The previous `resolveBin` modification actually broke all scripts (including `validate` which is used on CI, which caused false positives for everything... and `ci-after-success` which caused several releases to fail silently).
