### PR TITLE
✅ Fix custom test command tests with Yargs fix

### DIFF
--- a/src/scripts/__tests__/pre-commit.js
+++ b/src/scripts/__tests__/pre-commit.js
@@ -138,10 +138,10 @@ cases(
       args: ['--testCommand', '--config', 'some-config.js'],
     },
     'overrides built-in test command with --testCommand': {
-      args: ['--testCommand', '"yarn test:custom --findRelatedTests foo.js"'],
+      args: ['--testCommand', 'yarn test:custom --findRelatedTests foo.js'],
     },
     'overrides built-in test command with --test-command': {
-      args: ['--test-command', '"yarn test:custom --findRelatedTests foo.js"'],
+      args: ['--test-command', 'yarn test:custom --findRelatedTests foo.js'],
     },
     'overrides built-in test command with --testCommand and forwards args': {
       args: [
@@ -154,7 +154,7 @@ cases(
       args: [
         '--verbose',
         '--test-command',
-        '"yarn test:custom --findRelatedTests foo.js"',
+        'yarn test:custom --findRelatedTests foo.js',
       ],
     },
     'disables DocToc, overrides built-in test command, and forwards args': {
@@ -162,7 +162,7 @@ cases(
         '--verbose',
         '--no-toc',
         '--test-command',
-        '"yarn test:custom --findRelatedTests foo.js"',
+        'yarn test:custom --findRelatedTests foo.js',
         '--some-other-arg',
       ],
     },


### PR DESCRIPTION
Only the OS/shell should remove the quotes: https://github.com/yargs/yargs/issues/1324.

Since we're populating `process.argv` directly the quotes in the tests were treated as "inner quotes" (e.g: `'"some test command"'`). In actual usage the shell will remove quotes from something like `hover-scripts pre-commit --test-command='some test command'`.
