### PR TITLE
✨ Disable class-methods-use-this rule

### DIFF
--- a/src/config/__tests__/__snapshots__/eslintrc.js.snap
+++ b/src/config/__tests__/__snapshots__/eslintrc.js.snap
@@ -66,6 +66,7 @@ Object {
     "@typescript-eslint/no-implied-eval": "off",
     "@typescript-eslint/no-throw-literal": "off",
     "@typescript-eslint/return-await": "off",
+    "class-methods-use-this": "off",
     "import/no-extraneous-dependencies": Array [
       "error",
       Object {
@@ -197,6 +198,7 @@ Object {
     "@typescript-eslint/no-implied-eval": "off",
     "@typescript-eslint/no-throw-literal": "off",
     "@typescript-eslint/return-await": "off",
+    "class-methods-use-this": "off",
     "import/no-extraneous-dependencies": Array [
       "error",
       Object {

--- a/src/config/helpers/build-eslint.js
+++ b/src/config/helpers/build-eslint.js
@@ -51,6 +51,7 @@ const buildConfig = ({withReact = false} = {}) => {
       ifReact('plugin:react-hooks/recommended'),
     ].filter(Boolean),
     rules: {
+      'class-methods-use-this': 'off',
       'import/prefer-default-export': 'off',
       'import/no-extraneous-dependencies': [
         'error',


### PR DESCRIPTION
It makes the interface less stable. If you change a method between instance and class, you have to change all invocations. Whether or not it uses `this` is an implementation detail that should not matter for the interface