### PR TITLE
📝 Add note about setting package version for Semantic Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ module.exports = {
 
 #### Semantic Release
 
+> 🔖 Set the `version` field in your `package.json` to
+> `0.0.0-semantically-released` to enable Semantic Release in the
+> `ci-after-success` script
+
 Or, for Semantic Release (used in `ci-after-success` script) in
 `release.config.js`:
 


### PR DESCRIPTION
I think at some point it really makes sense to restructure the documentation so that each section matches a script name exactly, as it is a bit confusing that we wrap these tools in scripts but are then associating the documentation with the wrapped tool instead of the script that invokes said tool.

Anywho, in the meantime I at least want to document this behavior. I'm not entirely sure how much value it has, but it does seem somewhat important to prevent an arbitrary version from being hard-coded in the **package.json** as it will not be the current version when using Semantic Release.
