### PR TITLE
✨ Add exclude option to commitlint helper

### DIFF
--- a/src/api/__tests__/__fixtures__/ls/dirs/.gitignore
+++ b/src/api/__tests__/__fixtures__/ls/dirs/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/src/api/__tests__/commit.js
+++ b/src/api/__tests__/commit.js
@@ -26,9 +26,27 @@ describe('ls', () => {
     })
 
     test('with prefix', () => {
-      const result = ls.dirs(`${fixtures}/ls/dirs`, 'prefix')
+      const result = ls.dirs(`${fixtures}/ls/dirs`, {prefix: 'prefix'})
 
       const expected = ['prefix/.baz', 'prefix/bar', 'prefix/foo']
+
+      expect(result.sort()).toEqual(expected.sort())
+    })
+
+    test('with custom exclude (string)', () => {
+      const result = ls.dirs(`${fixtures}/ls/dirs`, {exclude: 'foo'})
+
+      const expected = ['.baz', 'bar', 'node_modules']
+
+      expect(result.sort()).toEqual(expected.sort())
+    })
+
+    test('with custom exclude (RegExp)', () => {
+      const result = ls.dirs(`${fixtures}/ls/dirs`, {
+        exclude: /(^node_modules|^bar)/,
+      })
+
+      const expected = ['.baz', 'foo']
 
       expect(result.sort()).toEqual(expected.sort())
     })

--- a/src/api/commit.js
+++ b/src/api/commit.js
@@ -45,16 +45,38 @@ const configs = path =>
     )
 
 /**
+ * @typedef DirsOptions
+ * @property {string} [prefix] prefix to prepend to each scope entry (e.g:
+ * `{ prefix: 'prefix' }` becomes `type(prefix/scope)`)
+ * @property {RegExp | string | null} [exclude] expression for excluding
+ * directories, defaults to `^node_modules`
+ */
+
+/**
  * Enumerate one level of directories
  *
  * @param {string} path - directory to enumerate
- * @param {string} [prefix] - prefix for each scope entry (e.g: `prefix/entry`)
+ * @param {DirsOptions} options -
  */
-const dirs = (path, prefix) =>
-  readdirSync(path)
-    .filter(f => statSync(join(path, f)).isDirectory())
+const dirs = (path, options) => {
+  const {exclude, prefix} = {exclude: /^node_modules/, ...options}
+
+  /**
+   * @param {string} f filename
+   */
+  const test = f => {
+    if (!exclude) return true
+
+    return !(typeof exclude === 'string'
+      ? f.includes(exclude)
+      : exclude.test(f))
+  }
+
+  return readdirSync(path)
+    .filter(f => statSync(join(path, f)).isDirectory() && test(f))
     .map(item => (prefix ? `${prefix}/${item}` : item))
     .map(item => item.toLowerCase())
+}
 
 const ls = {configs, dirs}
 


### PR DESCRIPTION
Update **commitlint** helper function, `ls.dirs()` to support excluding directories via an option and exclude `node_modules` folders by default.

> ⚠️  BREAKING CHANGE: `ls.dirs()` from `api/commit` now takes an options object as the second parameter instead of a `prefix`. If you're using a prefix you'll need to make the following change:

```ts
// Before
ls.dirs('./packages', 'my-prefix');

// After
ls.dirs('./packages', { prefix: 'my-prefix' });
```

> ⚠️ BREAKING CHANGE: `ls.dirs()` now excludes `node_modules` directories by default. If for some reason you want to include \`node_modules\`, you'll need to explicitly set \`exclude\` to \`null\`:
```ts
// Before
ls.dirs('./packages');

// After
ls.dirs('./packages', { exclude: null });
```
