### PR TITLE
🐛 Don't fail pre-commit when no related tests are found

### DIFF
--- a/src/config/helpers/build-lint-staged.js
+++ b/src/config/helpers/build-lint-staged.js
@@ -3,7 +3,7 @@ const {resolveHoverScripts, resolveBin} = require('../../utils')
 const hoverScripts = resolveHoverScripts()
 const doctoc = resolveBin('doctoc')
 
-const defaultTestCommand = `${hoverScripts} test --findRelatedTests`
+const defaultTestCommand = `${hoverScripts} test --findRelatedTests --passWithNoTests`
 
 const sourceExtensions = ['js', 'jsx', 'ts', 'tsx']
 

--- a/src/scripts/__tests__/__snapshots__/pre-commit.js.snap
+++ b/src/scripts/__tests__/__snapshots__/pre-commit.js.snap
@@ -17,7 +17,7 @@ Array [
 exports[`pre-commit disables DocToc and forwards args 2`] = `
 Array [
   .test-tmp/hover-javascriptTMPSUFFIX/.lintstaged.json,
-  {"*.+(js|jsx|json|json5|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["./src/index.js test --findRelatedTests"]},
+  {"*.+(js|jsx|json|json5|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)":["./src/index.js format"],"*.+(js|jsx|ts|tsx)":["./src/index.js lint"],"*.+(tsx|ts|jsx|js)":["./src/index.js test --findRelatedTests --passWithNoTests"]},
 ]
 `;
 


### PR DESCRIPTION
I'm not sure if this is new behavior or somehow I've just now started running into this... anyways, the `pre-commit` script is failing when `--findRelatedTests` turns up with no tests, so it seems we need to also pass `--passWithNoTests` to prevent failures when no related tests are found.
