### PR TITLE
🐛 Post 7.0 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,13 @@ module.exports = require('@hover/javascript/prettier')
 
 Or, for Jest in `jest.config.js`:
 
-> ℹ️ If **ts-jest** is installed, it will automatically be used as the `preset`
+> ⚠️ Starting with
+> [**7.0**](https://github.com/hoverinc/hover-javascript/releases/tag/v7.0.0),
+> the default Jest `transform` is
+> [**@swc-node/jest**](https://github.com/swc-project/swc-node/#swc-nodejest).
+> If you want to continue using
+> [**ts-jest**](https://kulshekhar.github.io/ts-jest/), simpy install `ts-jest`
+> in your project and it will automatically be used as the `transform` instead.
 
 ```js
 const config = require('@hover/javascript/jest')

--- a/src/api/commit.js
+++ b/src/api/commit.js
@@ -56,7 +56,7 @@ const configs = path =>
  * Enumerate one level of directories
  *
  * @param {string} path - directory to enumerate
- * @param {DirsOptions} options -
+ * @param {DirsOptions} [options] - options
  */
 const dirs = (path, options) => {
   const {exclude, prefix} = {exclude: /^node_modules/, ...options}

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -37,10 +37,18 @@ const jestConfig = {
     ? Object.fromEntries(
         // Ensure we can resolve the preset even when
         // it's in a nested `node_modules` installation
-        Object.entries(require('ts-jest/presets').transform).map(
-          ([glob, transformer]) => [
+        Object.entries(require('ts-jest/presets').jsWithTs.transform).map(
+          ([glob, [transformer, options]]) => [
             glob,
-            [require.resolve(transformer), {diagnostics: {warnOnly: true}}],
+            [
+              require.resolve(transformer),
+              {
+                ...options,
+                diagnostics: {
+                  warnOnly: true,
+                },
+              },
+            ],
           ],
         ),
       )

--- a/src/scripts/__tests__/__snapshots__/commit-msg.js.snap
+++ b/src/scripts/__tests__/__snapshots__/commit-msg.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`commit-msg adds env flag with HUSKY_GIT_PARAMS when available 1`] = `commitlint --env HUSKY_GIT_PARAMS --config ./src/config/commitlint.config.js`;
+exports[`commit-msg adds env flag with HUSKY_GIT_PARAMS when available 1`] = `TS_NODE_TRANSPILE_ONLY=true commitlint --env HUSKY_GIT_PARAMS --config ./src/config/commitlint.config.js`;
 
-exports[`commit-msg calls @commitlint/cli with default args 1`] = `commitlint --config ./src/config/commitlint.config.js --edit`;
+exports[`commit-msg calls @commitlint/cli with default args 1`] = `TS_NODE_TRANSPILE_ONLY=true commitlint --config ./src/config/commitlint.config.js --edit`;
 
-exports[`commit-msg defaults to \`--edit\` when no args are passed and HUSKY_GIT_PARAMS is not available 1`] = `commitlint --config ./src/config/commitlint.config.js --edit`;
+exports[`commit-msg defaults to \`--edit\` when no args are passed and HUSKY_GIT_PARAMS is not available 1`] = `TS_NODE_TRANSPILE_ONLY=true commitlint --config ./src/config/commitlint.config.js --edit`;
 
-exports[`commit-msg does not use built-in config with --config 1`] = `commitlint --config ./custom-config.js`;
+exports[`commit-msg does not use built-in config with --config 1`] = `TS_NODE_TRANSPILE_ONLY=true commitlint --config ./custom-config.js`;
 
-exports[`commit-msg does not use built-in config with commitlint.config.js file 1`] = `commitlint --edit`;
+exports[`commit-msg does not use built-in config with commitlint.config.js file 1`] = `TS_NODE_TRANSPILE_ONLY=true commitlint --edit`;
 
-exports[`commit-msg forwards args 1`] = `commitlint --config ./src/config/commitlint.config.js --edit .git/COMMIT_EDITMSG`;
+exports[`commit-msg forwards args 1`] = `TS_NODE_TRANSPILE_ONLY=true commitlint --config ./src/config/commitlint.config.js --edit .git/COMMIT_EDITMSG`;

--- a/src/scripts/commit-msg.js
+++ b/src/scripts/commit-msg.js
@@ -22,7 +22,9 @@ const config = useBuiltinConfig
   : []
 
 const result = spawn.sync(
-  resolveBin('@commitlint/cli', {executable: 'commitlint'}),
+  `TS_NODE_TRANSPILE_ONLY=true ${resolveBin('@commitlint/cli', {
+    executable: 'commitlint',
+  })}`,
   [...env, ...config, ...args, ...defaultEdit],
   {
     stdio: 'inherit',


### PR DESCRIPTION
- Update `api/commit` type definitions to reflect _optional_ options in `ls.dirs`
- Prevent **commitlint** from ever type-checking configuration
- Ensure **ts-jest** escape hatch works with latest version of **ts-jest**
- Update Jest documentation to reflect new default **@swc-node/jest** transform
