### PR TITLE
✨ Copy in ts-jest's path mapping helper

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -6,6 +6,7 @@
         "targets": {"node": "14"},
         "modules": "commonjs"
       }
-    ]
+    ],
+    "@babel/preset-typescript"
   ]
 }

--- a/.babelrc.json
+++ b/.babelrc.json
@@ -3,7 +3,7 @@
     [
       "@babel/preset-env",
       {
-        "targets": {"node": "12"},
+        "targets": {"node": "14"},
         "modules": "commonjs"
       }
     ]

--- a/api/test.js
+++ b/api/test.js
@@ -1,1 +1,1 @@
-module.exports = require('../dist/api/test')
+module.exports = require('../dist/api/test/index')

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "dist",
     "commitlint.js",
     "config.js",
-    "dist",
     "eslint-react.js",
     "eslint",
     "jest.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "run-p 'build:*'",
-    "build:source": "babel --source-maps --out-dir dist --ignore '**/__tests__/**','**/__mocks__/**' --copy-files --no-copy-ignored src",
+    "build:source": "babel --source-maps --extensions '.ts' --out-dir dist --ignore '**/__tests__/**','**/__mocks__/**' --copy-files --no-copy-ignored src",
     "build:types": "tsc -p src/",
     "ci-after-success": "node src ci-after-success",
     "commit": "node src commit",
@@ -132,6 +132,7 @@
     "@babel/cli": "^7.20.7",
     "@babel/core": "^7.20.12",
     "@babel/preset-env": "^7.20.2",
+    "@babel/preset-typescript": "^7.21.0",
     "@types/cross-spawn": "^6.0.2",
     "depcheck": "^1.4.3",
     "eslint-config-kentcdodds": "^20.4.0",

--- a/src/api/test/__tests__/__snapshots__/paths-to-module-name-mapper.ts.snap
+++ b/src/api/test/__tests__/__snapshots__/paths-to-module-name-mapper.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pathsToModuleNameMapper should convert tsconfig mapping with given prefix: <rootDir>/ 1`] = `
+Object {
+  "^@foo\\\\-bar/common$": "<rootDir>/../common/dist/library",
+  "^@pkg/(.*)$": "<rootDir>/packages/$1",
+  "^api/(.*)$": "<rootDir>/src/api/$1",
+  "^client$": Array [
+    "<rootDir>/src/client",
+    "<rootDir>/src/client/index",
+  ],
+  "^log$": "<rootDir>/src/utils/log",
+  "^mocks/(.*)$": "<rootDir>/test/mocks/$1",
+  "^server$": "<rootDir>/src/server",
+  "^test/(.*)$": "<rootDir>/test/$1",
+  "^test/(.*)/mock$": Array [
+    "<rootDir>/test/mocks/$1",
+    "<rootDir>/test/__mocks__/$1",
+  ],
+  "^util/(.*)$": "<rootDir>/src/utils/$1",
+}
+`;
+
+exports[`pathsToModuleNameMapper should convert tsconfig mapping with given prefix: foo 1`] = `
+Object {
+  "^@foo\\\\-bar/common$": "foo/../common/dist/library",
+  "^@pkg/(.*)$": "foo/packages/$1",
+  "^api/(.*)$": "foo/src/api/$1",
+  "^client$": Array [
+    "foo/src/client",
+    "foo/src/client/index",
+  ],
+  "^log$": "foo/src/utils/log",
+  "^mocks/(.*)$": "foo/test/mocks/$1",
+  "^server$": "foo/src/server",
+  "^test/(.*)$": "foo/test/$1",
+  "^test/(.*)/mock$": Array [
+    "foo/test/mocks/$1",
+    "foo/test/__mocks__/$1",
+  ],
+  "^util/(.*)$": "foo/src/utils/$1",
+}
+`;

--- a/src/api/test/__tests__/paths-to-module-name-mapper.ts
+++ b/src/api/test/__tests__/paths-to-module-name-mapper.ts
@@ -1,0 +1,104 @@
+import {pathsToModuleNameMapper} from '../paths-to-module-name-mapper'
+
+const tsconfigMap = {
+  log: ['src/utils/log'],
+  server: ['src/server'],
+  client: ['src/client', 'src/client/index'],
+  'util/*': ['src/utils/*'],
+  'api/*': ['src/api/*'],
+  'test/*': ['test/*'],
+  'mocks/*': ['test/mocks/*'],
+  'test/*/mock': ['test/mocks/*', 'test/__mocks__/*'],
+  '@foo-bar/common': ['../common/dist/library'],
+  '@pkg/*': ['./packages/*'],
+}
+
+describe('pathsToModuleNameMapper', () => {
+  test('should convert tsconfig mapping with no given prefix', () => {
+    expect(pathsToModuleNameMapper(tsconfigMap)).toMatchInlineSnapshot(`
+      Object {
+        "^@foo\\\\-bar/common$": "../common/dist/library",
+        "^@pkg/(.*)$": "./packages/$1",
+        "^api/(.*)$": "src/api/$1",
+        "^client$": Array [
+          "src/client",
+          "src/client/index",
+        ],
+        "^log$": "src/utils/log",
+        "^mocks/(.*)$": "test/mocks/$1",
+        "^server$": "src/server",
+        "^test/(.*)$": "test/$1",
+        "^test/(.*)/mock$": Array [
+          "test/mocks/$1",
+          "test/__mocks__/$1",
+        ],
+        "^util/(.*)$": "src/utils/$1",
+      }
+    `)
+  })
+
+  test('should add `js` extension to resolved config with useESM: true', () => {
+    expect(pathsToModuleNameMapper(tsconfigMap, {useESM: true})).toEqual({
+      /**
+       * Why not using snapshot here?
+       * Because the snapshot does not keep the property order, which is important for jest.
+       * A pattern ending with `\\.js` should appear before another pattern without the extension does.
+       */
+      '^log$': 'src/utils/log',
+      '^server$': 'src/server',
+      '^client$': ['src/client', 'src/client/index'],
+      '^util/(.*)\\.js$': 'src/utils/$1',
+      '^util/(.*)$': 'src/utils/$1',
+      '^api/(.*)\\.js$': 'src/api/$1',
+      '^api/(.*)$': 'src/api/$1',
+      '^test/(.*)\\.js$': 'test/$1',
+      '^test/(.*)$': 'test/$1',
+      '^mocks/(.*)\\.js$': 'test/mocks/$1',
+      '^mocks/(.*)$': 'test/mocks/$1',
+      '^test/(.*)/mock\\.js$': ['test/mocks/$1', 'test/__mocks__/$1'],
+      '^test/(.*)/mock$': ['test/mocks/$1', 'test/__mocks__/$1'],
+      '^@foo\\-bar/common$': '../common/dist/library',
+      '^@pkg/(.*)\\.js$': './packages/$1',
+      '^@pkg/(.*)$': './packages/$1',
+      '^(\\.{1,2}/.*)\\.js$': '$1',
+    })
+  })
+
+  test.each(['<rootDir>/', 'foo'])(
+    'should convert tsconfig mapping with given prefix',
+    prefix => {
+      expect(pathsToModuleNameMapper(tsconfigMap, {prefix})).toMatchSnapshot(
+        prefix,
+      )
+    },
+  )
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation()
+    })
+
+    afterEach(() => jest.mocked(console.warn).mockRestore())
+
+    test('should warn about mapping it cannot handle', () => {
+      expect(
+        pathsToModuleNameMapper({
+          kept: ['src/kept'],
+          'no-target': [],
+          'too/*/many/*/stars': ['to/*/many/*/stars'],
+        }),
+      ).toMatchInlineSnapshot(`
+        Object {
+          "^kept$": "src/kept",
+        }
+      `)
+
+      expect(jest.mocked(console.warn)).toHaveBeenCalledWith(
+        'Not mapping "no-target" because it has no target.',
+      )
+      expect(jest.mocked(console.warn)).toHaveBeenCalledWith(
+        'Not mapping "too/*/many/*/stars" because it has more than one star (`*`).',
+      )
+    })
+  })
+})

--- a/src/api/test/index.ts
+++ b/src/api/test/index.ts
@@ -1,0 +1,1 @@
+export {pathsToModuleNameMapper} from './paths-to-module-name-mapper'

--- a/src/api/test/paths-to-module-name-mapper.ts
+++ b/src/api/test/paths-to-module-name-mapper.ts
@@ -1,0 +1,76 @@
+/**
+ * NOTE: this was copy pasta'ed from `ts-jest` so that we can support path
+ * aliases in `tsconfig.json` without necessarily relying on `ts-jest`
+ *
+ * @see {@link https://github.com/kulshekhar/ts-jest/blob/dd3523cb7571714f06f1ea2ed1e3cf11970fbfce/src/config/paths-to-module-name-mapper.ts}
+ */
+
+import type {Config} from '@jest/types'
+import type {CompilerOptions} from 'typescript'
+
+type TsPathMapping = Exclude<CompilerOptions['paths'], undefined>
+type JestPathMapping = Config.InitialOptions['moduleNameMapper']
+
+// we don't need to escape all chars, so commented out is the real one
+// const escapeRegex = (str: string) => str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+const escapeRegex = (str: string) => str.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
+
+export const pathsToModuleNameMapper = (
+  mapping: TsPathMapping,
+  {prefix = '', useESM = false}: {prefix?: string; useESM?: boolean} = {},
+): JestPathMapping => {
+  const jestMap: JestPathMapping = {}
+  for (const fromPath of Object.keys(mapping)) {
+    const toPaths = mapping[fromPath]
+    // check that we have only one target path
+    if (toPaths.length === 0) {
+      console.warn(`Not mapping "${fromPath}" because it has no target.`)
+
+      continue
+    }
+
+    // split with '*'
+    const segments = fromPath.split(/\*/g)
+    if (segments.length === 1) {
+      const paths = toPaths.map(target => {
+        const enrichedPrefix =
+          prefix !== '' && !prefix.endsWith('/') ? `${prefix}/` : prefix
+
+        return `${enrichedPrefix}${target}`
+      })
+      const cjsPattern = `^${escapeRegex(fromPath)}$`
+      jestMap[cjsPattern] = paths.length === 1 ? paths[0] : paths
+    } else if (segments.length === 2) {
+      const paths = toPaths.map(target => {
+        const enrichedTarget =
+          target.startsWith('./') && prefix !== ''
+            ? target.substring(target.indexOf('/') + 1)
+            : target
+        const enrichedPrefix =
+          prefix !== '' && !prefix.endsWith('/') ? `${prefix}/` : prefix
+
+        return `${enrichedPrefix}${enrichedTarget.replace(/\*/g, '$1')}`
+      })
+      if (useESM) {
+        const esmPattern = `^${escapeRegex(segments[0])}(.*)${escapeRegex(
+          segments[1],
+        )}\\.js$`
+        jestMap[esmPattern] = paths.length === 1 ? paths[0] : paths
+      }
+      const cjsPattern = `^${escapeRegex(segments[0])}(.*)${escapeRegex(
+        segments[1],
+      )}$`
+      jestMap[cjsPattern] = paths.length === 1 ? paths[0] : paths
+    } else {
+      console.warn(
+        `Not mapping "${fromPath}" because it has more than one star (\`*\`).`,
+      )
+    }
+  }
+
+  if (useESM) {
+    jestMap['^(\\.{1,2}/.*)\\.js$'] = '$1'
+  }
+
+  return jestMap
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,6 +8,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "../dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "skipLibCheck": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-create-class-features-plugin@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.21.0"
+  dependencies:
+    "@babel/helper-annotate-as-pure": ^7.18.6
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.21.0
+    "@babel/helper-member-expression-to-functions": ^7.21.0
+    "@babel/helper-optimise-call-expression": ^7.18.6
+    "@babel/helper-replace-supers": ^7.20.7
+    "@babel/helper-skip-transparent-expression-wrappers": ^7.20.0
+    "@babel/helper-split-export-declaration": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 3e781d91d1056ea9b3a0395f3017492594a8b86899119b4a1645227c31727b8bec9bc8f6b72e86b1c5cf2dd6690893d2e8c5baff4974c429e616ead089552a21
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.20.5":
   version: 7.20.5
   resolution: "@babel/helper-create-regexp-features-plugin@npm:7.20.5"
@@ -217,6 +235,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-function-name@npm:7.21.0"
+  dependencies:
+    "@babel/template": ^7.20.7
+    "@babel/types": ^7.21.0
+  checksum: d63e63c3e0e3e8b3138fa47b0cd321148a300ef12b8ee951196994dcd2a492cc708aeda94c2c53759a5c9177fffaac0fd8778791286746f72a000976968daf4e
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-hoist-variables@npm:7.18.6"
@@ -232,6 +260,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.20.7
   checksum: cec17aab7e964830b0146e575bd141127032319f26ed864a65b35abd75ad618d264d3e11449b9b4e29cfd95bb1a7e774afddd4884fdcc29c36ac9cbd2b66359f
+  languageName: node
+  linkType: hard
+
+"@babel/helper-member-expression-to-functions@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.21.0"
+  dependencies:
+    "@babel/types": ^7.21.0
+  checksum: 49cbb865098195fe82ba22da3a8fe630cde30dcd8ebf8ad5f9a24a2b685150c6711419879cf9d99b94dad24cff9244d8c2a890d3d7ec75502cd01fe58cff5b5d
   languageName: node
   linkType: hard
 
@@ -349,6 +386,13 @@ __metadata:
   version: 7.18.6
   resolution: "@babel/helper-validator-option@npm:7.18.6"
   checksum: f9cc6eb7cc5d759c5abf006402180f8d5e4251e9198197428a97e05d65eb2f8ae5a0ce73b1dfd2d35af41d0eb780627a64edf98a4e71f064eeeacef8de58f2cf
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/helper-validator-option@npm:7.21.0"
+  checksum: 8ece4c78ffa5461fd8ab6b6e57cc51afad59df08192ed5d84b475af4a7193fc1cb794b59e3e7be64f3cdc4df7ac78bf3dbb20c129d7757ae078e6279ff8c2f07
   languageName: node
   linkType: hard
 
@@ -815,6 +859,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-typescript@npm:^7.20.0":
+  version: 7.20.0
+  resolution: "@babel/plugin-syntax-typescript@npm:7.20.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.19.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6189c0b5c32ba3c9a80a42338bd50719d783b20ef29b853d4f03929e971913d3cefd80184e924ae98ad6db09080be8fe6f1ffde9a6db8972523234f0274d36f7
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-typescript@npm:^7.7.2":
   version: 7.12.13
   resolution: "@babel/plugin-syntax-typescript@npm:7.12.13"
@@ -1182,6 +1237,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-typescript@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/plugin-transform-typescript@npm:7.21.0"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.21.0
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/plugin-syntax-typescript": ^7.20.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 091931118eb515738a4bc8245875f985fc9759d3f85cdf08ee641779b41520241b369404e2bb86fc81907ad827678fdb704e8e5a995352def5dd3051ea2cd870
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-unicode-escapes@npm:^7.18.10":
   version: 7.18.10
   resolution: "@babel/plugin-transform-unicode-escapes@npm:7.18.10"
@@ -1305,6 +1373,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-typescript@npm:^7.21.0":
+  version: 7.21.0
+  resolution: "@babel/preset-typescript@npm:7.21.0"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/helper-validator-option": ^7.21.0
+    "@babel/plugin-transform-typescript": ^7.21.0
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6e1f4d7294de2678fbaf36035e98847b2be432f40fe7a1204e5e45b8b05bcbe22902fe0d726e16af14de5bc08987fae28a7899871503fd661050d85f58755af6
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.16.3, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.8.4":
   version: 7.20.7
   resolution: "@babel/runtime@npm:7.20.7"
@@ -1354,7 +1435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.8.3":
+"@babel/types@npm:^7.21.0, @babel/types@npm:^7.8.3":
   version: 7.21.2
   resolution: "@babel/types@npm:7.21.2"
   dependencies:
@@ -1684,6 +1765,7 @@ __metadata:
     "@babel/cli": ^7.20.7
     "@babel/core": ^7.20.12
     "@babel/preset-env": ^7.20.2
+    "@babel/preset-typescript": ^7.21.0
     "@commitlint/cli": ^17.4.4
     "@commitlint/config-conventional": ^17.4.4
     "@commitlint/prompt": ^17.4.4


### PR DESCRIPTION
Make **ts-jest**'s `pathsToModuleNameMapper` helper available at `/api/test`.

Note: this _copies_ in the module name mapper helper from `ts-jest` so we can use that whether we're using **ts-jest** or not. I couldn't find an alternative helper that doesn't pull in a million dependencies ([**alias-hq**](https://github.com/davestewart/alias-hq) being the only solid alternative I found).
